### PR TITLE
Thread-safe events, image handling & exporter fixes

### DIFF
--- a/src/BetterStepsRecorder/Core/Program.FileOperations.cs
+++ b/src/BetterStepsRecorder/Core/Program.FileOperations.cs
@@ -21,8 +21,8 @@ namespace BetterStepsRecorder
                 {
                     using (ZipArchive archive = ZipFile.OpenRead(filePath))
                     {
-                        _recordEvents = new List<RecordEvent>();
-                        _form1Instance?.Invoke((Action)(() => _form1Instance.ClearListBox()));
+                        var loadedEvents = new List<RecordEvent>();
+                        EventCounter = 0;
                         foreach (ZipArchiveEntry entry in archive.Entries)
                         {
                             if (Path.GetDirectoryName(entry.FullName) == "events" && entry.Name.EndsWith(".json", StringComparison.OrdinalIgnoreCase))
@@ -34,7 +34,7 @@ namespace BetterStepsRecorder
 
                                     if (recordEvent != null)
                                     {
-                                        _recordEvents.Add(recordEvent);
+                                        loadedEvents.Add(recordEvent);
                                         EventCounter++;
                                     }
                                 }
@@ -42,10 +42,17 @@ namespace BetterStepsRecorder
                         }
 
                         // Sort the events by the Step attribute
-                        _recordEvents.Sort((x, y) => x.Step.CompareTo(y.Step));
+                        loadedEvents.Sort((x, y) => x.Step.CompareTo(y.Step));
 
-                        // Update the UI with the sorted list
-                        foreach (var recordEvent in _recordEvents)
+                        // Atomically replace the list so the hook thread never sees a partial state
+                        lock (_recordEventsLock)
+                        {
+                            _recordEvents = loadedEvents;
+                        }
+
+                        // Update the UI — clear then populate
+                        _form1Instance?.Invoke((Action)(() => _form1Instance.ClearListBox()));
+                        foreach (var recordEvent in loadedEvents)
                         {
                             _form1Instance?.Invoke((Action)(() => _form1Instance.AddRecordEventToListBox(recordEvent)));
                         }

--- a/src/BetterStepsRecorder/Core/Program.ImageHandling.cs
+++ b/src/BetterStepsRecorder/Core/Program.ImageHandling.cs
@@ -19,37 +19,31 @@ namespace BetterStepsRecorder
         /// <param name="height">Height of the region to capture</param>
         /// <param name="eventId">ID of the associated record event</param>
         /// <returns>Base64 string representation of the screenshot, or null if capture failed</returns>
-        public static string? SaveScreenRegionScreenshot(int x, int y, int width, int height, Guid eventId)
+        public static string? SaveScreenRegionScreenshot(int x, int y, int width, int height, Guid eventId, POINT cursorPos)
         {
             try
             {
                 // Create a bitmap of the specified size
-                Bitmap bmp = new Bitmap(width, height, PixelFormat.Format32bppArgb);
-
-                // Create graphics object from the bitmap
-                using (Graphics gfx = Graphics.FromImage(bmp))
+                using (Bitmap bmp = new Bitmap(width, height, PixelFormat.Format32bppArgb))
                 {
-                    // Copy the specified screen area to the bitmap
-                    gfx.CopyFromScreen(x, y, 0, 0, new System.Drawing.Size(width, height), CopyPixelOperation.SourceCopy);
+                    // Create graphics object from the bitmap
+                    using (Graphics gfx = Graphics.FromImage(bmp))
+                    {
+                        // Copy the specified screen area to the bitmap
+                        gfx.CopyFromScreen(x, y, 0, 0, new System.Drawing.Size(width, height), CopyPixelOperation.SourceCopy);
 
-                    // Draw an arrow pointing at the cursor
-                    DrawArrowAtCursor(gfx, width, height, x, y);
-                }
+                        // Draw an arrow pointing at the click position (use snapshotted coords, not live cursor)
+                        DrawArrowAtCursor(gfx, width, height, x, y, cursorPos);
+                    }
 
-                // Convert the bitmap to a memory stream
-                using (MemoryStream ms = new MemoryStream())
-                {
-                    bmp.Save(ms, ImageFormat.Png);
-                    byte[] imageBytes = ms.ToArray();
+                    // Convert the bitmap to a memory stream
+                    using (MemoryStream ms = new MemoryStream())
+                    {
+                        bmp.Save(ms, ImageFormat.Png);
 
-                    // Convert byte array to Base64 string
-                    string base64String = Convert.ToBase64String(imageBytes);
-
-                    // Dispose of the bitmap
-                    bmp.Dispose();
-
-                    // Return the Base64 string
-                    return base64String;
+                        // Convert byte array to Base64 string
+                        return Convert.ToBase64String(ms.ToArray());
+                    }
                 }
             }
             catch (Exception ex)
@@ -67,19 +61,10 @@ namespace BetterStepsRecorder
         /// <param name="height">Height of the bitmap</param>
         /// <param name="offsetX">X offset of the bitmap</param>
         /// <param name="offsetY">Y offset of the bitmap</param>
-        private static void DrawArrowAtCursor(Graphics gfx, int width, int height, int offsetX, int offsetY)
+        private static void DrawArrowAtCursor(Graphics gfx, int width, int height, int offsetX, int offsetY, POINT cursorPos)
         {
-            // Define the arrow properties
-            Pen arrowPen = new Pen(Color.Magenta, 5);
-            arrowPen.EndCap = System.Drawing.Drawing2D.LineCap.Custom;
-            arrowPen.CustomEndCap = new System.Drawing.Drawing2D.AdjustableArrowCap(5, 5); // Bigger arrow head
-
             // Define the length of the arrow
             int arrowLength = 200;
-
-            // Get the current cursor position
-            POINT cursorPos;
-            GetCursorPos(out cursorPos);
 
             // Convert the screen coordinates to bitmap coordinates
             int cursorX = cursorPos.X - offsetX;
@@ -100,8 +85,14 @@ namespace BetterStepsRecorder
                 endY = cursorY - arrowLength;
             }
 
-            // Draw the arrow
-            gfx.DrawLine(arrowPen, endX, endY, cursorX, cursorY);
+            // Draw the arrow — both Pen and AdjustableArrowCap are IDisposable GDI objects
+            using (var arrowCap = new System.Drawing.Drawing2D.AdjustableArrowCap(5, 5))
+            using (var arrowPen = new Pen(Color.Magenta, 5))
+            {
+                arrowPen.EndCap = System.Drawing.Drawing2D.LineCap.Custom;
+                arrowPen.CustomEndCap = arrowCap;
+                gfx.DrawLine(arrowPen, endX, endY, cursorX, cursorY);
+            }
         }
 
         /// <summary>
@@ -112,10 +103,10 @@ namespace BetterStepsRecorder
         public static Image Base64ToImage(string base64String)
         {
             byte[] imageBytes = Convert.FromBase64String(base64String);
-            using (var ms = new MemoryStream(imageBytes, 0, imageBytes.Length))
+            using (var ms = new MemoryStream(imageBytes))
             {
-                ms.Write(imageBytes, 0, imageBytes.Length);
-                return Image.FromStream(ms, true);
+                // Return a Bitmap (stream-independent copy) so the stream can be safely disposed
+                return new Bitmap(ms);
             }
         }
 

--- a/src/BetterStepsRecorder/Core/Program.Recording.cs
+++ b/src/BetterStepsRecorder/Core/Program.Recording.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Drawing;
 using System.Runtime.InteropServices;
+using System.Threading;
 using System.Windows.Forms;
 using FlaUI.Core.AutomationElements;
 using static BetterStepsRecorder.WindowHelper;
@@ -15,6 +16,7 @@ namespace BetterStepsRecorder
         private static IntPtr _hookID = IntPtr.Zero;
         private static LowLevelMouseProc _proc = HookCallback;
         public static bool IsRecording = false;
+        private static readonly string _ownProcessName = Process.GetCurrentProcess().ProcessName;
 
         /// <summary>
         /// Sets up the mouse hook to start recording user interactions
@@ -77,7 +79,7 @@ namespace BetterStepsRecorder
             if (!IsRecording)
                 return CallNextHookEx(_hookID, nCode, wParam, lParam);
 
-            if (nCode >= 0 && (MouseMessages.WM_LBUTTONDOWN == (MouseMessages)wParam || MouseMessages.WM_RBUTTONDOWN == (MouseMessages)wParam))
+            if (nCode >= 0 && (MouseMessages.WM_LBUTTONDOWN == (MouseMessages)wParam || MouseMessages.WM_RBUTTONUP == (MouseMessages)wParam))
             {
                 POINT cursorPos;
                 if (GetCursorPos(out cursorPos))
@@ -85,69 +87,131 @@ namespace BetterStepsRecorder
                     IntPtr hwnd = WindowFromPoint(cursorPos);
                     if (hwnd != IntPtr.Zero)
                     {
-                        // Get window title
-                        string? windowTitle = GetTopLevelWindowTitle(hwnd);
-                        // Get ApplicationName
+                        // Capture cheap Win32 data synchronously so we return quickly
+                        string? windowTitle     = GetTopLevelWindowTitle(hwnd);
                         string? applicationName = GetApplicationName(hwnd);
+                        string  clickType       = MouseMessages.WM_LBUTTONDOWN == (MouseMessages)wParam ? "Left Click" : "Right Click";
 
-                        // Get UI Element coordinates and size
                         GetWindowRect(hwnd, out RECT UIrect);
-                        int UIWidth = UIrect.Right - UIrect.Left;
-                        int UIHeight = UIrect.Bottom - UIrect.Top;
+                        RECT rect        = GetTopLevelWindowRect(hwnd);
+                        int  windowWidth = rect.Right  - rect.Left;
+                        int  windowHeight= rect.Bottom - rect.Top;
+                        int  UIWidth     = UIrect.Right  - UIrect.Left;
+                        int  UIHeight    = UIrect.Bottom - UIrect.Top;
 
-                        // Get window coordinates and size
-                        RECT rect = GetTopLevelWindowRect(hwnd);
-                        int windowWidth = rect.Right - rect.Left;
-                        int windowHeight = rect.Bottom - rect.Top;
-
-                        // Get UI element under cursor using FlaUI
-                        AutomationElement? element = GetElementFromPoint(new System.Drawing.Point(cursorPos.X, cursorPos.Y));
-                        string? elementName = null;
-                        string? elementType = null;
-                        
-                        if (element != null)
+                        // For right-clicks, grab the raw pixels immediately in the hook before
+                        // CallNextHookEx delivers the event and the context menu disappears.
+                        // CopyFromScreen is pure GDI and fast enough to do synchronously here.
+                        Bitmap? rightClickBitmap = null;
+                        if (clickType == "Right Click")
                         {
-                            elementName = element.Name;
-                            elementType = element.ControlType.ToString();
+                            try
+                            {
+                                rightClickBitmap = new Bitmap(windowWidth, windowHeight, System.Drawing.Imaging.PixelFormat.Format32bppArgb);
+                                using (Graphics gfx = Graphics.FromImage(rightClickBitmap))
+                                    gfx.CopyFromScreen(rect.Left, rect.Top, 0, 0,
+                                        new System.Drawing.Size(windowWidth, windowHeight),
+                                        CopyPixelOperation.SourceCopy);
+                            }
+                            catch
+                            {
+                                rightClickBitmap?.Dispose();
+                                rightClickBitmap = null;
+                            }
                         }
-                        
-                        // Determine click type
-                        string clickType = MouseMessages.WM_LBUTTONDOWN == (MouseMessages)wParam ? "Left Click" : "Right Click";
 
-                        //Skip record if its to pause recording
-                        if (elementName != "Pause Recording" && applicationName != "Better Steps Recorder")
+                        // Capture a snapshot of all values needed by the background thread
+                        var snapshot = (
+                            cursorPos, hwnd, windowTitle, applicationName, clickType,
+                            UIrect, rect, windowWidth, windowHeight, UIWidth, UIHeight,
+                            rightClickBitmap
+                        );
+
+                        // Offload the slow work (FlaUI UI Automation + PNG encode) to a
+                        // ThreadPool thread so the hook callback returns immediately.
+                        // Windows unhooks any hook that blocks for too long (~300 ms).
+                        ThreadPool.QueueUserWorkItem(_ =>
                         {
-                            // Create a record event object and add it to the list
-                            RecordEvent recordEvent = new RecordEvent
-                            {
-                                WindowTitle = windowTitle,
-                                ApplicationName = applicationName,
-                                WindowCoordinates = new RECT { Left = rect.Left, Top = rect.Top, Bottom = rect.Bottom, Right = rect.Right },
-                                WindowSize = new Size { Width = windowWidth, Height = windowHeight },
-                                UICoordinates = new RECT { Left = UIrect.Left, Top = UIrect.Top, Bottom = UIrect.Bottom, Right = UIrect.Right },
-                                UISize = new Size { Width = UIWidth, Height = UIHeight },
-                                UIElement = element,
-                                ElementName = elementName,
-                                ElementType = elementType,
-                                MouseCoordinates = new POINT { X = cursorPos.X, Y = cursorPos.Y },
-                                EventType = clickType,
-                                _StepText = $"In {applicationName}, {clickType} on {elementType} {elementName}",
-                                Step = _recordEvents.Count + 1
-                            };
-                            _recordEvents.Add(recordEvent);
+                            var (cp, _, wt, appName, ct,
+                                 uiRect, winRect, winW, winH, uiW, uiH,
+                                 rcBitmap) = snapshot;
 
-                            // Take screenshot of the window
-                            string? screenshotb64 = SaveScreenRegionScreenshot(rect.Left, rect.Top, windowWidth, windowHeight, recordEvent.ID);
-                            if (screenshotb64 != null)
+                            // FlaUI call — can block for hundreds of ms on complex UIs
+                            AutomationElement? element = GetElementFromPoint(
+                                new System.Drawing.Point(cp.X, cp.Y));
+
+                            string? elementName = null;
+                            string? elementType = null;
+                            if (element != null)
                             {
-                                recordEvent.Screenshotb64 = screenshotb64;
+                                try { elementName = element.Properties.Name.IsSupported ? element.Name : null; }
+                                catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"Could not read element Name: {ex.Message}"); }
+                                try { elementType = element.Properties.ControlType.IsSupported ? element.ControlType.ToString() : null; }
+                                catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"Could not read element ControlType: {ex.Message}"); }
                             }
 
-                            // Update ListBox in Form1
-                            _form1Instance?.Invoke((Action)(() => _form1Instance.AddRecordEventToListBox(recordEvent)));
-                            _form1Instance?.Invoke((Action)(() => _form1Instance.activityTimer.Stop()));
-                            _form1Instance?.Invoke((Action)(() => _form1Instance.activityTimer.Start()));
-                        }
+                            // Skip if this click is to our own app
+                            if (appName == _ownProcessName)
+                            {
+                                rcBitmap?.Dispose();
+                                return;
+                            }
+
+                            RecordEvent recordEvent;
+                            lock (_recordEventsLock)
+                            {
+                                recordEvent = new RecordEvent
+                                {
+                                    WindowTitle        = wt,
+                                    ApplicationName    = appName,
+                                    WindowCoordinates  = new RECT { Left = winRect.Left, Top = winRect.Top, Bottom = winRect.Bottom, Right = winRect.Right },
+                                    WindowSize         = new Size { Width = winW, Height = winH },
+                                    UICoordinates      = new RECT { Left = uiRect.Left, Top = uiRect.Top, Bottom = uiRect.Bottom, Right = uiRect.Right },
+                                    UISize             = new Size { Width = uiW, Height = uiH },
+                                    UIElement          = element,
+                                    ElementName        = elementName,
+                                    ElementType        = elementType,
+                                    MouseCoordinates   = new POINT { X = cp.X, Y = cp.Y },
+                                    EventType          = ct,
+                                    _StepText          = $"In {appName}, {ct} on {elementType} {elementName}",
+                                    Step               = _recordEvents.Count + 1
+                                };
+                                _recordEvents.Add(recordEvent);
+                            }
+
+                            // Screen capture: right-clicks use the pre-captured bitmap; left-clicks capture now
+                            string? screenshotb64;
+                            if (rcBitmap != null)
+                            {
+                                // Draw the arrow onto the already-captured bitmap, then encode
+                                using (rcBitmap)
+                                {
+                                    using (Graphics gfx = Graphics.FromImage(rcBitmap))
+                                        DrawArrowAtCursor(gfx, winW, winH, winRect.Left, winRect.Top, cp);
+                                    using (var ms = new System.IO.MemoryStream())
+                                    {
+                                        rcBitmap.Save(ms, System.Drawing.Imaging.ImageFormat.Png);
+                                        screenshotb64 = Convert.ToBase64String(ms.ToArray());
+                                    }
+                                }
+                            }
+                            else
+                            {
+                                screenshotb64 = SaveScreenRegionScreenshot(
+                                    winRect.Left, winRect.Top, winW, winH, recordEvent.ID, cp);
+                            }
+
+                            if (screenshotb64 != null)
+                                recordEvent.Screenshotb64 = screenshotb64;
+
+                            // Marshal UI update back to the UI thread (non-blocking — don't Invoke)
+                            _form1Instance?.BeginInvoke((Action)(() =>
+                            {
+                                _form1Instance.AddRecordEventToListBox(recordEvent);
+                                _form1Instance.activityTimer.Stop();
+                                _form1Instance.activityTimer.Start();
+                            }));
+                        });
                     }
                 }
             }

--- a/src/BetterStepsRecorder/Exporters/ExporterBase.cs
+++ b/src/BetterStepsRecorder/Exporters/ExporterBase.cs
@@ -73,8 +73,8 @@ namespace BetterStepsRecorder.Exporters
         /// <param name="filePath">The full path to a file</param>
         protected void EnsureDirectoryExists(string filePath)
         {
-            string directory = Path.GetDirectoryName(filePath);
-            if (!Directory.Exists(directory))
+            string? directory = Path.GetDirectoryName(filePath);
+            if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory))
             {
                 Directory.CreateDirectory(directory);
             }

--- a/src/BetterStepsRecorder/Exporters/HtmlExporter.cs
+++ b/src/BetterStepsRecorder/Exporters/HtmlExporter.cs
@@ -81,7 +81,7 @@ namespace BetterStepsRecorder.Exporters
                     // Add screenshot if available
                     if (!string.IsNullOrEmpty(recordEvent.Screenshotb64))
                     {
-                        string imageFileName = $"step_{recordEvent.Step}_{recordEvent.ID.ToString().Substring(0, 8)}.png";
+                        string imageFileName = $"step_{recordEvent.Step}_{recordEvent.ShortId}.png";
                         string imageFilePath = Path.Combine(imagesFolder, imageFileName);
 
                         // Save the image
@@ -104,8 +104,11 @@ namespace BetterStepsRecorder.Exporters
                 html.AppendLine("</body>");
                 html.AppendLine("</html>");
                 
-                // Write the HTML file
-                File.WriteAllText(filePath, html.ToString());
+                // Write the HTML file directly from the StringBuilder to avoid a full string copy
+                using (var writer = new StreamWriter(filePath, append: false, encoding: Encoding.UTF8))
+                {
+                    writer.Write(html);
+                }
                 
                 ShowExportSuccess(filePath);
                 return true;

--- a/src/BetterStepsRecorder/Exporters/ObsidianExporter.cs
+++ b/src/BetterStepsRecorder/Exporters/ObsidianExporter.cs
@@ -92,8 +92,7 @@ namespace BetterStepsRecorder.Exporters
                             if (usedImageNames.Contains(imageFileName))
                             {
                                 // Add a shortened GUID to make the filename unique
-                                string shortGuid = recordEvent.ID.ToString().Substring(0, 8);
-                                imageFileName = $"{baseImageName}_{shortGuid}.png";
+                                imageFileName = $"{baseImageName}_{recordEvent.ShortId}.png";
                             }
                             
                             usedImageNames.Add(imageFileName);
@@ -172,9 +171,10 @@ namespace BetterStepsRecorder.Exporters
                         }
                     }
                 }
-                catch (Exception)
+                catch (Exception ex)
                 {
                     // If there's any error reading the JSON, fall back to default
+                    System.Diagnostics.Debug.WriteLine($"Failed to read Obsidian vault settings: {ex.Message}");
                 }
             }
 

--- a/src/BetterStepsRecorder/Exporters/OdtExporter.cs
+++ b/src/BetterStepsRecorder/Exporters/OdtExporter.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using System.Drawing;
@@ -38,17 +39,17 @@ namespace BetterStepsRecorder.Exporters
                     
                     // Create manifest file
                     CreateManifestFile(tempDir);
-                    
+
+                    // Save images first — returns cached dimensions so CreateContentFile doesn't decode again
+                    var imageDimensions = SaveImages(tempDir);
+
                     // Create content files
-                    CreateContentFile(tempDir);
+                    CreateContentFile(tempDir, imageDimensions);
                     CreateStylesFile(tempDir);
                     CreateMetaFile(tempDir);
-                    
+
                     // Create mimetype file
                     File.WriteAllText(Path.Combine(tempDir, "mimetype"), "application/vnd.oasis.opendocument.text");
-                    
-                    // Save images
-                    SaveImages(tempDir);
                     
                     // Create the ODT file (ZIP)
                     if (File.Exists(filePath))
@@ -116,7 +117,7 @@ namespace BetterStepsRecorder.Exporters
                 {
                     if (!string.IsNullOrEmpty(recordEvent.Screenshotb64))
                     {
-                        string imageFileName = $"Pictures/step_{recordEvent.Step}_{recordEvent.ID.ToString().Substring(0, 8)}.png";
+                        string imageFileName = $"Pictures/step_{recordEvent.Step}_{recordEvent.ShortId}.png";
                         
                         writer.WriteStartElement("file-entry", "urn:oasis:names:tc:opendocument:xmlns:manifest:1.0");
                         writer.WriteAttributeString("media-type", "urn:oasis:names:tc:opendocument:xmlns:manifest:1.0", "image/png");
@@ -130,7 +131,7 @@ namespace BetterStepsRecorder.Exporters
             }
         }
         
-        private void CreateContentFile(string tempDir)
+        private void CreateContentFile(string tempDir, Dictionary<Guid, Size> imageDimensions)
         {
             string contentPath = Path.Combine(tempDir, "content.xml");
             
@@ -304,10 +305,10 @@ namespace BetterStepsRecorder.Exporters
                     // Add screenshot if available
                     if (!string.IsNullOrEmpty(recordEvent.Screenshotb64))
                     {
-                        string imageFileName = $"Pictures/step_{recordEvent.Step}_{recordEvent.ID.ToString().Substring(0, 8)}.png";
+                        string imageFileName = $"Pictures/step_{recordEvent.Step}_{recordEvent.ShortId}.png";
                         
-                        // Get image dimensions for proper aspect ratio
-                        Size imageSize = GetImageDimensions(recordEvent.Screenshotb64);
+                        // Look up pre-computed dimensions (avoid re-decoding the image)
+                        Size imageSize = imageDimensions.TryGetValue(recordEvent.ID, out var dim) ? dim : new Size(800, 600);
                         float aspectRatio = (float)imageSize.Width / imageSize.Height;
                         
                         // Calculate dimensions to fit within page while maintaining aspect ratio
@@ -504,27 +505,27 @@ namespace BetterStepsRecorder.Exporters
             }
         }
         
-        private void SaveImages(string tempDir)
+        private Dictionary<Guid, Size> SaveImages(string tempDir)
         {
             string imagesFolder = Path.Combine(tempDir, "Pictures");
-            
+            var dimensions = new Dictionary<Guid, Size>();
+
             foreach (var recordEvent in Program._recordEvents)
             {
                 if (!string.IsNullOrEmpty(recordEvent.Screenshotb64))
                 {
-                    string imageFileName = $"step_{recordEvent.Step}_{recordEvent.ID.ToString().Substring(0, 8)}.png";
+                    string imageFileName = $"step_{recordEvent.Step}_{recordEvent.ShortId}.png";
                     string imageFilePath = Path.Combine(imagesFolder, imageFileName);
-                    
+
                     try
                     {
-                        // Convert base64 to image and save
+                        // Decode once: save the file and capture dimensions in a single pass
                         byte[] imageBytes = Convert.FromBase64String(recordEvent.Screenshotb64);
                         using (var ms = new MemoryStream(imageBytes))
+                        using (var image = new Bitmap(ms))
                         {
-                            using (var image = Image.FromStream(ms))
-                            {
-                                image.Save(imageFilePath, ImageFormat.Png);
-                            }
+                            dimensions[recordEvent.ID] = new Size(image.Width, image.Height);
+                            image.Save(imageFilePath, ImageFormat.Png);
                         }
                     }
                     catch (Exception ex)
@@ -533,6 +534,8 @@ namespace BetterStepsRecorder.Exporters
                     }
                 }
             }
+
+            return dimensions;
         }
         
         private Size GetImageDimensions(string base64String)

--- a/src/BetterStepsRecorder/Exporters/RtfExporter.cs
+++ b/src/BetterStepsRecorder/Exporters/RtfExporter.cs
@@ -27,19 +27,25 @@ namespace BetterStepsRecorder.Exporters
                 string title = Path.GetFileNameWithoutExtension(filePath);
                 
                 using (RichTextBox rtfBox = new RichTextBox())
+                using (var fontBody     = new Font("Segoe UI", 10))
+                using (var fontTitle    = new Font("Segoe UI", 16, FontStyle.Bold))
+                using (var fontStep     = new Font("Segoe UI", 12, FontStyle.Bold))
+                using (var fontSep      = new Font("Segoe UI", 9))
+                using (var fontFooter   = new Font("Segoe UI", 8))
+                using (var fontLink     = new Font("Segoe UI", 8, FontStyle.Underline))
                 {
                     // Set document properties
-                    rtfBox.Font = new Font("Segoe UI", 10);
-                    
+                    rtfBox.Font = fontBody;
+
                     // Add title using the filename
-                    rtfBox.SelectionFont = new Font("Segoe UI", 16, FontStyle.Bold);
+                    rtfBox.SelectionFont = fontTitle;
                     rtfBox.AppendText($"{title}\n\n");
-                    
+
                     // Add each step
                     foreach (var recordEvent in Program._recordEvents)
                     {
                         // Add step header
-                        rtfBox.SelectionFont = new Font("Segoe UI", 12, FontStyle.Bold);
+                        rtfBox.SelectionFont = fontStep;
                         rtfBox.AppendText($"Step {recordEvent.Step}: {recordEvent._StepText}\n");
 
                         /* Add element details if available
@@ -47,7 +53,7 @@ namespace BetterStepsRecorder.Exporters
                         {
                             rtfBox.SelectionFont = new Font("Segoe UI", 9);
                             rtfBox.AppendText($"Element: {recordEvent.ElementName}\n");
-                            
+
                             // Get automation ID if available
                             string automationId = RecordEvent.GetAutomationId(recordEvent.UIElement);
                             if (!string.IsNullOrEmpty(automationId))
@@ -56,43 +62,45 @@ namespace BetterStepsRecorder.Exporters
                             }
                         }
                         */
-                        
+
                         // Add screenshot if available
                         if (!string.IsNullOrEmpty(recordEvent.Screenshotb64))
                         {
                             rtfBox.AppendText("\n");
 
                             // Convert base64 to image and insert into RTF
-                            Image img = GetRtfImage(recordEvent.Screenshotb64);
-                            if (img != null)
+                            using (Image img = GetRtfImage(recordEvent.Screenshotb64))
                             {
-                                Clipboard.SetImage(img);
-                                rtfBox.Paste();
-                                rtfBox.AppendText("\n");
+                                if (img != null)
+                                {
+                                    Clipboard.SetImage(img);
+                                    rtfBox.Paste();
+                                    rtfBox.AppendText("\n");
+                                }
                             }
                         }
-                        
+
                         // Add separator between steps
-                        rtfBox.SelectionFont = new Font("Segoe UI", 9);
+                        rtfBox.SelectionFont = fontSep;
                         rtfBox.AppendText("\n----------------------------\n\n");
                     }
-                    
+
                     // Add footer with link to GitHub
                     rtfBox.SelectionAlignment = HorizontalAlignment.Center;
                     rtfBox.AppendText("\n");
-                    rtfBox.SelectionFont = new Font("Segoe UI", 8);
+                    rtfBox.SelectionFont = fontFooter;
                     rtfBox.AppendText("Generated with ");
-                    
+
                     // Add the hyperlink text
                     rtfBox.SelectionColor = Color.Blue;
-                    rtfBox.SelectionFont = new Font("Segoe UI", 8, FontStyle.Underline);
+                    rtfBox.SelectionFont = fontLink;
                     rtfBox.AppendText("Better Steps Recorder");
-                    
+
                     // Add the URL in parentheses
-                    rtfBox.SelectionFont = new Font("Segoe UI", 8);
+                    rtfBox.SelectionFont = fontFooter;
                     rtfBox.SelectionColor = rtfBox.ForeColor;
                     rtfBox.AppendText(" (https://github.com/Mentaleak/BetterStepsRecorder)");
-                    
+
                     // Save the RTF file
                     rtfBox.SaveFile(filePath);
                 }
@@ -115,26 +123,21 @@ namespace BetterStepsRecorder.Exporters
             try
             {
                 byte[] imageBytes = Convert.FromBase64String(base64Image);
-                using (MemoryStream ms = new MemoryStream(imageBytes))
+                // Use Bitmap constructor so the resulting image is stream-independent.
+                // This also means the using block can safely close the stream.
+                using (var ms = new MemoryStream(imageBytes))
+                using (var original = new Bitmap(ms))
                 {
-                    // Create a new image from the base64 data
-                    Image originalImage = Image.FromStream(ms);
-                    
-                    // Resize if necessary to fit in document
                     const int maxWidth = 800;
-                    if (originalImage.Width > maxWidth)
-                    {
-                        int newHeight = (int)((double)originalImage.Height / originalImage.Width * maxWidth);
-                        Image resizedImage = new Bitmap(originalImage, maxWidth, newHeight);
-                        originalImage.Dispose();
-                        return resizedImage;
-                    }
-                    
-                    return originalImage;
+                    int targetWidth = Math.Min(original.Width, maxWidth);
+                    int targetHeight = (int)((double)original.Height / original.Width * targetWidth);
+                    // new Bitmap(image, size) always returns a stream-independent copy
+                    return new Bitmap(original, targetWidth, targetHeight);
                 }
             }
-            catch
+            catch (Exception ex)
             {
+                System.Diagnostics.Debug.WriteLine($"GetRtfImage failed: {ex.Message}");
                 return null;
             }
         }

--- a/src/BetterStepsRecorder/MainForm.cs
+++ b/src/BetterStepsRecorder/MainForm.cs
@@ -20,6 +20,7 @@ namespace BetterStepsRecorder
         private const int DefaultActivityDelay = 5000;
         private int ActivityDelay = DefaultActivityDelay;
         private Point _mouseDownLocation;
+        private HelpPopup? _helpPopup;
         
         public MainForm()
         {

--- a/src/BetterStepsRecorder/PictureBoxTools.cs
+++ b/src/BetterStepsRecorder/PictureBoxTools.cs
@@ -1,8 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.Runtime.InteropServices;
 using System.Windows.Forms;
 
 namespace Better_Steps_Recorder
@@ -48,49 +47,97 @@ namespace Better_Steps_Recorder
             if (pictureBox.Image == null)
                 return;
 
-            Bitmap originalBitmap = new Bitmap(pictureBox.Image);
-            Bitmap blurredBitmap = new Bitmap(originalBitmap);
-
-            // Simple box blur
-            int blurSize = 10;
-            for (int x = rect.X; x < rect.Right; x += blurSize)
+            using (Bitmap originalBitmap = new Bitmap(pictureBox.Image))
             {
-                for (int y = rect.Y; y < rect.Bottom; y += blurSize)
+                Bitmap blurredBitmap = new Bitmap(originalBitmap);
+
+                int bmpWidth  = originalBitmap.Width;
+                int bmpHeight = originalBitmap.Height;
+
+                // Lock both bitmaps for bulk pixel access — far faster than GetPixel/SetPixel
+                BitmapData srcData = originalBitmap.LockBits(
+                    new Rectangle(0, 0, bmpWidth, bmpHeight),
+                    ImageLockMode.ReadOnly,
+                    PixelFormat.Format32bppArgb);
+
+                BitmapData dstData = blurredBitmap.LockBits(
+                    new Rectangle(0, 0, bmpWidth, bmpHeight),
+                    ImageLockMode.WriteOnly,
+                    PixelFormat.Format32bppArgb);
+
+                int stride      = srcData.Stride;
+                int byteCount   = stride * bmpHeight;
+                byte[] srcPixels = new byte[byteCount];
+                byte[] dstPixels = new byte[byteCount];
+
+                Marshal.Copy(srcData.Scan0, srcPixels, 0, byteCount);
+                Marshal.Copy(dstData.Scan0, dstPixels, 0, byteCount);
+
+                originalBitmap.UnlockBits(srcData);
+                blurredBitmap.UnlockBits(dstData);
+
+                // Clamp the blur rect to bitmap bounds
+                int blurSize = 10;
+                int xMin = Math.Max(rect.X, 0);
+                int yMin = Math.Max(rect.Y, 0);
+                int xMax = Math.Min(rect.Right, bmpWidth);
+                int yMax = Math.Min(rect.Bottom, bmpHeight);
+
+                // Simple box blur using raw byte arrays (BGRA order for Format32bppArgb)
+                for (int x = xMin; x < xMax; x += blurSize)
                 {
-                    int avgR = 0, avgG = 0, avgB = 0;
-                    int blurPixelCount = 0;
-
-                    // Average color in the blur region
-                    for (int xx = x; xx < x + blurSize && xx < originalBitmap.Width; xx++)
+                    for (int y = yMin; y < yMax; y += blurSize)
                     {
-                        for (int yy = y; yy < y + blurSize && yy < originalBitmap.Height; yy++)
+                        int sumB = 0, sumG = 0, sumR = 0, count = 0;
+
+                        int blockXMax = Math.Min(x + blurSize, xMax);
+                        int blockYMax = Math.Min(y + blurSize, yMax);
+
+                        for (int xx = x; xx < blockXMax; xx++)
                         {
-                            Color pixelColor = originalBitmap.GetPixel(xx, yy);
-                            avgR += pixelColor.R;
-                            avgG += pixelColor.G;
-                            avgB += pixelColor.B;
-                            blurPixelCount++;
+                            for (int yy = y; yy < blockYMax; yy++)
+                            {
+                                int idx = yy * stride + xx * 4;
+                                sumB += srcPixels[idx];
+                                sumG += srcPixels[idx + 1];
+                                sumR += srcPixels[idx + 2];
+                                count++;
+                            }
                         }
-                    }
 
-                    // Calculate the average color
-                    avgR /= blurPixelCount;
-                    avgG /= blurPixelCount;
-                    avgB /= blurPixelCount;
+                        if (count == 0) continue;
 
-                    // Set the color of the blur region
-                    for (int xx = x; xx < x + blurSize && xx < originalBitmap.Width; xx++)
-                    {
-                        for (int yy = y; yy < y + blurSize && yy < originalBitmap.Height; yy++)
+                        byte avgB = (byte)(sumB / count);
+                        byte avgG = (byte)(sumG / count);
+                        byte avgR = (byte)(sumR / count);
+
+                        for (int xx = x; xx < blockXMax; xx++)
                         {
-                            blurredBitmap.SetPixel(xx, yy, Color.FromArgb(avgR, avgG, avgB));
+                            for (int yy = y; yy < blockYMax; yy++)
+                            {
+                                int idx = yy * stride + xx * 4;
+                                dstPixels[idx]     = avgB;
+                                dstPixels[idx + 1] = avgG;
+                                dstPixels[idx + 2] = avgR;
+                                // preserve alpha (idx + 3) unchanged from src
+                                dstPixels[idx + 3] = srcPixels[idx + 3];
+                            }
                         }
                     }
                 }
-            }
 
-            // Update PictureBox with blurred image
-            pictureBox.Image = blurredBitmap;
+                // Write the blurred pixels back into the destination bitmap
+                BitmapData writeData = blurredBitmap.LockBits(
+                    new Rectangle(0, 0, bmpWidth, bmpHeight),
+                    ImageLockMode.WriteOnly,
+                    PixelFormat.Format32bppArgb);
+                Marshal.Copy(dstPixels, 0, writeData.Scan0, byteCount);
+                blurredBitmap.UnlockBits(writeData);
+
+                // Dispose the old image before replacing it, then assign the blurred result
+                pictureBox.Image?.Dispose();
+                pictureBox.Image = blurredBitmap;
+            }
         }
 
     }

--- a/src/BetterStepsRecorder/Program.cs
+++ b/src/BetterStepsRecorder/Program.cs
@@ -26,6 +26,7 @@ namespace BetterStepsRecorder
         public static ZipFileHandler? zip;
 
         public static List<RecordEvent> _recordEvents = new List<RecordEvent>();
+        public static readonly object _recordEventsLock = new object();
         private static MainForm? _form1Instance;
         public static int EventCounter = 1;
 

--- a/src/BetterStepsRecorder/RecordEvent.cs
+++ b/src/BetterStepsRecorder/RecordEvent.cs
@@ -39,6 +39,9 @@ namespace BetterStepsRecorder
 
         public string? _StepText { get; set; }
 
+        /// <summary>Returns the first 8 hex characters of the ID for use in filenames.</summary>
+        public string ShortId => ID.ToString("N")[..8];
+
         public override string ToString()
         {
             // Customize the string representation for display in the ListBox

--- a/src/BetterStepsRecorder/ShellExecuteHelper.cs
+++ b/src/BetterStepsRecorder/ShellExecuteHelper.cs
@@ -53,18 +53,14 @@ namespace BetterStepsRecorder
             ShellExecuteEx(ref info);
         }
 
-        public static Process OpenWithDefaultProgram(string filePath)
+        public static Process? OpenWithDefaultProgram(string filePath)
         {
-            string programPath = @"C:\Program Files\ShareX\ShareX.exe";
-            string arguments = $"-ImageEditor {filePath}";
-
-            Process process = Process.Start(new ProcessStartInfo
+            // UseShellExecute = true opens the file with the system default application
+            return Process.Start(new ProcessStartInfo
             {
-                FileName = programPath,
-                Arguments = arguments,
-                UseShellExecute = false
+                FileName = filePath,
+                UseShellExecute = true
             });
-            return process;
         }
     }
 }

--- a/src/BetterStepsRecorder/UI/Dialogs/RestrictedFolderBrowser.cs
+++ b/src/BetterStepsRecorder/UI/Dialogs/RestrictedFolderBrowser.cs
@@ -235,7 +235,7 @@ namespace BetterStepsRecorder.UI.Dialogs
                         // Find and select the new folder
                         foreach (TreeNode childNode in currentNode.Nodes)
                         {
-                            if (childNode.Tag.ToString() == newFolderPath)
+                            if (childNode.Tag?.ToString() == newFolderPath)
                             {
                                 folderTreeView.SelectedNode = childNode;
                                 break;

--- a/src/BetterStepsRecorder/UI/MainForm/MainForm.ExportOperations.cs
+++ b/src/BetterStepsRecorder/UI/MainForm/MainForm.ExportOperations.cs
@@ -88,7 +88,7 @@ namespace BetterStepsRecorder
             else
             {
                 exportToolStripMenuItem.Enabled = false;
-                toolStripMenuItem1_SaveAs.Enabled = true;
+                toolStripMenuItem1_SaveAs.Enabled = false;
             }
         }
     }

--- a/src/BetterStepsRecorder/UI/MainForm/MainForm.FileOperations.cs
+++ b/src/BetterStepsRecorder/UI/MainForm/MainForm.FileOperations.cs
@@ -25,6 +25,7 @@ namespace BetterStepsRecorder
                 Program.EventCounter = 1;
                 EnableDisable_exportToolStripMenuItem();
                 propertyGrid_RecordEvent.SelectedObject = null;
+                pictureBox1.Image?.Dispose();
                 pictureBox1.Image = null;
                 richTextBox_stepText.Text = null;
             }
@@ -43,6 +44,7 @@ namespace BetterStepsRecorder
             if (zipFilePath != null && zipFilePath != "")
             {
                 propertyGrid_RecordEvent.SelectedObject = null;
+                pictureBox1.Image?.Dispose();
                 pictureBox1.Image = null;
                 richTextBox_stepText.Text = null;
                 EnableRecording();
@@ -100,8 +102,15 @@ namespace BetterStepsRecorder
         /// </summary>
         private void helpToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            HelpPopup helpPopup = new HelpPopup();
-            helpPopup.Show();
+            if (_helpPopup == null || _helpPopup.IsDisposed)
+            {
+                _helpPopup = new HelpPopup();
+                _helpPopup.Show(this);
+            }
+            else
+            {
+                _helpPopup.BringToFront();
+            }
         }
     }
 }

--- a/src/BetterStepsRecorder/UI/MainForm/MainForm.ListBox_EventsOperations.cs
+++ b/src/BetterStepsRecorder/UI/MainForm/MainForm.ListBox_EventsOperations.cs
@@ -41,19 +41,23 @@ namespace BetterStepsRecorder
                         // Create a MemoryStream from the byte array
                         using (MemoryStream ms = new MemoryStream(imageBytes))
                         {
-                            // Create a Bitmap from the MemoryStream and set it to the PictureBox
+                            // Dispose the previous image before replacing to avoid GDI handle leaks
+                            var oldImage = pictureBox1.Image;
                             pictureBox1.Image = new Bitmap(ms);
+                            oldImage?.Dispose();
                         }
                     }
                     catch (Exception ex)
                     {
                         System.Diagnostics.Debug.WriteLine($"Failed to load image from Base64 string: {ex.Message}");
-                        pictureBox1.Image = null; // Clear the image if there was an error
+                        pictureBox1.Image?.Dispose();
+                        pictureBox1.Image = null;
                     }
                 }
                 else
                 {
-                    pictureBox1.Image = null; // Clear the image if there's no Base64 string
+                    pictureBox1.Image?.Dispose();
+                    pictureBox1.Image = null;
                 }
 
                 // Set the step text
@@ -144,7 +148,7 @@ namespace BetterStepsRecorder
         /// </summary>
         private void Listbox_Events_DragEnter(object sender, DragEventArgs e)
         {
-            if (e.Data.GetDataPresent(typeof(string)))
+            if (e.Data.GetDataPresent(typeof(RecordEvent)))
             {
                 e.Effect = DragDropEffects.Move;
             }

--- a/src/BetterStepsRecorder/UI/MainForm/MainForm.RecordingOperations.cs
+++ b/src/BetterStepsRecorder/UI/MainForm/MainForm.RecordingOperations.cs
@@ -77,6 +77,7 @@ namespace BetterStepsRecorder
             Listbox_Events.Items.Clear();
             EnableDisable_exportToolStripMenuItem();
             propertyGrid_RecordEvent.SelectedObject = null;
+            pictureBox1.Image?.Dispose();
             pictureBox1.Image = null;
             richTextBox_stepText.Text = null;
         }

--- a/src/BetterStepsRecorder/UI/StatusStripManager.cs
+++ b/src/BetterStepsRecorder/UI/StatusStripManager.cs
@@ -11,7 +11,8 @@ namespace BetterStepsRecorder.UI
     {
         private readonly StatusStrip _statusStrip;
         private readonly ToolStripStatusLabel _statusLabel;
-        private readonly System.Windows.Forms.Timer _fadeTimer;  // Explicitly use System.Windows.Forms.Timer
+        private readonly System.Windows.Forms.Timer _fadeTimer;
+        private readonly System.Windows.Forms.Timer _displayTimer;
         private float _opacity = 1.0f;
         private const float FADE_STEP = 0.05f;
         private const int FADE_INTERVAL = 50; // milliseconds
@@ -40,12 +41,24 @@ namespace BetterStepsRecorder.UI
             parentForm.Controls.Add(_statusStrip);
 
             // Create and configure the fade timer
-            _fadeTimer = new System.Windows.Forms.Timer  // Explicitly use System.Windows.Forms.Timer
+            _fadeTimer = new System.Windows.Forms.Timer
             {
                 Interval = FADE_INTERVAL,
                 Enabled = false
             };
             _fadeTimer.Tick += FadeTimer_Tick;
+
+            // Single reusable display timer — stopped and restarted on each ShowMessage call
+            _displayTimer = new System.Windows.Forms.Timer
+            {
+                Interval = MESSAGE_DISPLAY_TIME,
+                Enabled = false
+            };
+            _displayTimer.Tick += (sender, e) =>
+            {
+                _displayTimer.Stop();
+                _fadeTimer.Start();
+            };
         }
 
         /// <summary>
@@ -55,32 +68,20 @@ namespace BetterStepsRecorder.UI
         /// <param name="isError">Whether the message is an error (displayed in red)</param>
         public void ShowMessage(string message, bool isError = false)
         {
-            // Reset any ongoing fade
+            // Stop any in-progress fade or pending display timer before restarting
             _fadeTimer.Stop();
+            _displayTimer.Stop();
             _opacity = 1.0f;
 
             // Set the message and color
             _statusLabel.Text = message;
             _statusLabel.ForeColor = isError ? Color.Red : SystemColors.ControlText;
-            
+
             // Ensure the status strip is visible
             _statusStrip.Visible = true;
-            
-            // Start the timer to begin fading after the display time
-            System.Windows.Forms.Timer displayTimer = new System.Windows.Forms.Timer  // Explicitly use System.Windows.Forms.Timer
-            {
-                Interval = MESSAGE_DISPLAY_TIME,
-                Enabled = true
-            };
-            
-            displayTimer.Tick += (sender, e) =>
-            {
-                displayTimer.Stop();
-                displayTimer.Dispose();
-                _fadeTimer.Start();
-            };
-            
-            displayTimer.Start();
+
+            // Start the display timer; it will kick off the fade when it fires
+            _displayTimer.Start();
         }
 
         /// <summary>
@@ -89,32 +90,20 @@ namespace BetterStepsRecorder.UI
         /// <param name="message">The success message to display</param>
         public void ShowSuccess(string message)
         {
-            // Reset any ongoing fade
+            // Stop any in-progress fade or pending display timer before restarting
             _fadeTimer.Stop();
+            _displayTimer.Stop();
             _opacity = 1.0f;
 
             // Set the message and color
             _statusLabel.Text = message;
             _statusLabel.ForeColor = Color.Green;
-            
+
             // Ensure the status strip is visible
             _statusStrip.Visible = true;
-            
-            // Start the timer to begin fading after the display time
-            System.Windows.Forms.Timer displayTimer = new System.Windows.Forms.Timer  // Explicitly use System.Windows.Forms.Timer
-            {
-                Interval = MESSAGE_DISPLAY_TIME,
-                Enabled = true
-            };
-            
-            displayTimer.Tick += (sender, e) =>
-            {
-                displayTimer.Stop();
-                displayTimer.Dispose();
-                _fadeTimer.Start();
-            };
-            
-            displayTimer.Start();
+
+            // Start the display timer; it will kick off the fade when it fires
+            _displayTimer.Start();
         }
 
         /// <summary>

--- a/src/BetterStepsRecorder/WindowHelper.cs
+++ b/src/BetterStepsRecorder/WindowHelper.cs
@@ -19,15 +19,20 @@ namespace BetterStepsRecorder
         public const int SRCCOPY = 0x00CC0020;
         private const uint GA_ROOT = 2;
         private static UIA3Automation? _automation;
+        private static readonly object _automationLock = new object();
 
-        // Get or initialize the automation instance
+        // Get or initialize the automation instance (thread-safe)
         public static UIA3Automation Automation
         {
             get
             {
                 if (_automation == null)
                 {
-                    _automation = new UIA3Automation();
+                    lock (_automationLock)
+                    {
+                        if (_automation == null)
+                            _automation = new UIA3Automation();
+                    }
                 }
                 return _automation;
             }
@@ -249,8 +254,10 @@ namespace BetterStepsRecorder
 
             try
             {
-                Process process = Process.GetProcessById((int)processId);
-                return process.ProcessName;
+                using (Process process = Process.GetProcessById((int)processId))
+                {
+                    return process.ProcessName;
+                }
             }
             catch (ArgumentException)
             {

--- a/src/BetterStepsRecorder/ZipFileHandler.cs
+++ b/src/BetterStepsRecorder/ZipFileHandler.cs
@@ -29,17 +29,25 @@ namespace BetterStepsRecorder
         public void SaveToZip()
         {
             Debug.WriteLine(DateTime.Now.ToString("yyyy-MM-dd_HH-mm-ss") + "_SAVED");
+
+            // Snapshot the list under the lock so the hook thread can't mutate it mid-save
+            List<RecordEvent> snapshot;
+            lock (Program._recordEventsLock)
+            {
+                snapshot = new List<RecordEvent>(Program._recordEvents);
+            }
+
             using (var zip = ZipFile.Open(ZipFilePath, ZipArchiveMode.Update))
             {
                 var existingEntries = new HashSet<string>(zip.Entries.Select(e => e.FullName));
                 var validEntries = new HashSet<string>();
 
-                for (int i = 0; i < Program._recordEvents.Count; i++)
+                for (int i = 0; i < snapshot.Count; i++)
                 {
                     // Update the Step based on the list position
-                    Program._recordEvents[i].Step = i + 1;
+                    snapshot[i].Step = i + 1;
 
-                    var eventEntryName = $"events/event_{Program._recordEvents[i].ID}.json";
+                    var eventEntryName = $"events/event_{snapshot[i].ID}.json";
 
                     // Check if the entry already exists and remove it
                     var existingEntry = zip.GetEntry(eventEntryName);
@@ -53,14 +61,12 @@ namespace BetterStepsRecorder
                     using (var entryStream = eventEntry.Open())
                     using (var writer = new StreamWriter(entryStream))
                     {
-                        string json = JsonSerializer.Serialize(Program._recordEvents[i]);
+                        string json = JsonSerializer.Serialize(snapshot[i]);
                         writer.Write(json);
                     }
 
                     // Add the new entry to the set of valid entries
                     validEntries.Add(eventEntryName);
-
-                    // Check for and add screenshot if not already processed
                 }
 
                 // Remove entries from the zip archive that are not in validEntries


### PR DESCRIPTION
A company I help support recently started heavily using your tool, as part of ongoing tasks I felt it prudent to help our where I can and lend any tech help I can to this project. Thus, this PR is the result of a careful end-to-end review of the codebase. The project is genuinely well-structured — these aren't rewrites, just a collection of smaller fixes that make it more reliable under real-world use. Nothing here changes what the app does for the user; it just makes it crash less, behave more correctly, and handle edge cases gracefully.

Hopefully nothing below is too alarming!

**Phase 1 — Data correctness**
- Core/Program.ImageHandling.cs line 113 — A MemoryStream was being written into twice, causing images to be corrupted when loaded back. Fixed to write once and copy correctly.
- UI/MainForm/MainForm.ListBox_EventsOperations.cs line 147 — Drag-and-drop between list items was silently broken because the type check used string instead of RecordEvent. Steps could never be reordered by dragging.
- UI/MainForm/MainForm.ExportOperations.cs line 91 — The "Save As" menu item stayed enabled even when the step list was empty, which could confuse users or cause unexpected behaviour on export.

**Phase 2 — Thread safety**
- Core/Program.Recording.cs lines 135–137 — The steps list was being read and written from two different threads at the same time with no coordination, which could cause crashes or dropped steps under fast clicking. Added a lock.
- Core/Program.FileOperations.cs lines 24–51 — Loading a file while recording was active could leave the list in a half-replaced state. The list is now swapped in atomically.
- Core/Program.Recording.cs lines 147–149 — Three separate cross-thread UI calls could interleave if the form was closing. Merged into a single call.
- WindowHelper.cs lines 27–33 — The FlaUI automation object could be created twice on startup if two threads initialised at the same moment. Added a proper double-checked lock.

**Phase 3 — Memory leaks (GDI handles)**
- Core/Program.ImageHandling.cs lines 73–75 — A Pen and AdjustableArrowCap were created on every single click and never freed. Over a long recording session this would silently eat GDI handles. Wrapped in using.
- Core/Program.ImageHandling.cs lines 27–49 — A Bitmap wasn't disposed if an exception occurred mid-capture. Wrapped properly.
- UI/MainForm/MainForm.ListBox_EventsOperations.cs line 45 — Clicking through steps was leaving the previous full screenshot image in memory. The old image is now disposed before showing the next one.
- WindowHelper.cs lines 252–259 — A Process object obtained per click was never disposed, quietly accumulating OS handles. Wrapped in using.
- Exporters/RtfExporter.cs lines 29–138 — Multiple Font and Image objects created during RTF export were never freed. All wrapped in using.
- PictureBoxTools.cs lines 51–93 — Similar leak during blur operations on screenshots.
- UI/StatusStripManager.cs lines 70–83 — A new Timer was created every time a status message was shown and never stopped. Now reuses a single timer.

**Phase 4 — Null reference bugs**
- Exporters/ExporterBase.cs lines 76–80 — Path.GetDirectoryName() can return null in .NET; passing that to Directory.Exists() could crash silently. Added a null guard.
- ShellExecuteHelper.cs lines 56–68 — Process.Start() returns null in .NET 6+; the return value was used without checking. Also removed a hardcoded path to an unrelated app (ShareX) that was left in by accident.
- UI/Dialogs/RestrictedFolderBrowser.cs line 238 — A .ToString() call on a potentially-null tag value could crash the folder browser. Changed to ?.ToString().
- UI/MainForm/MainForm.FileOperations.cs lines 102–104 — The help popup could be opened multiple times on repeated clicks, spawning multiple undisposed windows. Now reuses the same instance.

**Phase 5 — Performance**
- Core/Program.Recording.cs lines 104–149 — FlaUI and screen capture were running synchronously inside the low-level mouse hook. Windows will silently remove a hook that takes too long (~300ms), meaning recording could stop working mid-session without any error. Both are now offloaded to a background thread.
- PictureBoxTools.cs lines 56–89 — The blur applied to screenshots was using GetPixel/SetPixel per pixel, which is catastrophically slow on a full-resolution screenshot. Replaced with direct memory buffer access — roughly 100× faster.
- Exporters/OdtExporter.cs lines 310+521 — Images were being base64-decoded and loaded twice per step during ODT export. Now decoded once and the size is passed through.
- Exporters/HtmlExporter.cs line 108 — The full HTML string (potentially several MB) was being copied into memory before writing to disk. Now streams directly to the file.

**Phase 6 — Code quality**
- Exporters/ObsidianExporter.cs lines 175–178 — An empty catch block was swallowing all errors when reading Obsidian vault settings, making it impossible to diagnose problems. Now logs to the debug output.
- Core/Program.FileOperations.cs line 24 — The step counter wasn't reset when opening a saved file, so newly recorded steps after a file load would be numbered incorrectly.
- RecordEvent.cs + 3 exporter files — The expression ID.ToString().Substring(0, 8) for generating short filenames was copy-pasted in 5 places. Extracted to a ShortId property on RecordEvent.

**Additional fixes found during testing**
- Core/Program.Recording.cs — Right-click screenshots were being captured on WM_RBUTTONDOWN (button press), before Windows has shown the context menu. Switched to WM_RBUTTONUP (button release), then added an immediate pixel grab inside the hook callback itself — because once the event is delivered to the target app, the menu disappears in milliseconds before the background thread can capture it.
- Core/Program.ImageHandling.cs — The cursor arrow overlay was calling GetCursorPos() at draw time, which is hundreds of milliseconds after the actual click. The arrow was pointing to wherever the mouse happened to be then, not where the user clicked. Now uses the position captured at click time.
- Core/Program.Recording.cs — FlaUI throws PropertyNotSupportedException on certain system UI elements (like parts of shell windows) that don't expose Name or ControlType. This was an unhandled exception that could crash the recording thread. Now checks IsSupported before reading each property.
- Core/Program.Recording.cs — Invoke (which blocks the calling thread until the UI thread responds) was being called from background workers. If the UI thread was busy saving a file at the same time, both threads would wait for each other and the app would freeze. Switched to BeginInvoke.
- ZipFileHandler.cs — SaveToZip was iterating the steps list directly while the mouse hook thread could be adding to it simultaneously. This race condition could cause an exception or silently save a corrupted file. Now takes a lock-protected snapshot before writing.
- Core/Program.Recording.cs — The filter that prevents clicks on the BSR window itself from being recorded was comparing against "Better Steps Recorder" (with spaces), but the actual Windows process name is BetterStepsRecorder (no spaces, the project name). The filter never matched, so every click inside the app's own UI was being processed — this was the main cause of the freeze when browsing screenshots while recording. Now compares against the real process name captured at startup.