### PR TITLE
Update MainForm.ImageRedaction.cs

### DIFF
--- a/src/BetterStepsRecorder/UI/MainForm/MainForm.ImageRedaction.cs
+++ b/src/BetterStepsRecorder/UI/MainForm/MainForm.ImageRedaction.cs
@@ -412,7 +412,10 @@ namespace BetterStepsRecorder
                 stack = new Stack<string>();
                 _undoStacks[evt.ID] = stack;
             }
-            stack.Push(evt.Screenshotb64 ?? string.Empty);
+            // Capture the current image bytes (RAM or spool) so undo can restore it correctly
+            byte[]? currentBytes = Program.GetScreenshotBytes(evt);
+            string previousState = currentBytes != null ? Convert.ToBase64String(currentBytes) : string.Empty;
+            stack.Push(previousState);
             undoToolStripButton.Enabled = true;
 
             var oldImage = pictureBox1.Image;


### PR DESCRIPTION
Fixes https://github.com/Mentaleak/BetterStepsRecorder/issues/11

What was wrong: CommitBitmap pushed evt.Screenshotb64 ?? string.Empty onto the undo stack. When the screenshot was stored in a spool file, Screenshotb64 was null, so string.Empty got pushed. Undoing to that empty string cleared the picture box instead of showing the original image, my bad!