### PR TITLE
Added Settings for ODT, RTF, Obsidian 

### DIFF
--- a/src/BetterStepsRecorder/BetterStepsRecorder.csproj
+++ b/src/BetterStepsRecorder/BetterStepsRecorder.csproj
@@ -8,7 +8,7 @@
     <UseWindowsForms>true</UseWindowsForms>
     <ImplicitUsings>enable</ImplicitUsings>
     <ApplicationIcon>stepsrecorder_r2p_icon.ico</ApplicationIcon>
-	<Version>2026.3.26.0022</Version>
+	<Version>2026.3.29.2040</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BetterStepsRecorder/Core/Settings/BSRSettingsDefaultsClasses.cs
+++ b/src/BetterStepsRecorder/Core/Settings/BSRSettingsDefaultsClasses.cs
@@ -99,10 +99,67 @@ namespace BetterStepsRecorder
                 !ShowElement && !ShowElementType && !ShowMousePosition;
         }
 
+        public class RtfSettings
+        {
+            public bool ShowSummary { get; set; } = true;
+            public bool ShowGeneratedDate { get; set; } = true;
+            public bool ShowStepTimestamps { get; set; } = false;
+            public bool ShowAction { get; set; } = false;
+            public bool ShowApplication { get; set; } = false;
+            public bool ShowWindow { get; set; } = false;
+            public bool ShowElement { get; set; } = false;
+            public bool ShowElementType { get; set; } = false;
+            public bool ShowMousePosition { get; set; } = false;
+
+            [JsonIgnore]
+            public bool IsDetailStripEmpty =>
+                !ShowAction && !ShowApplication && !ShowWindow &&
+                !ShowElement && !ShowElementType && !ShowMousePosition;
+        }
+
+        public class OdtSettings
+        {
+            public bool ShowSummary { get; set; } = true;
+            public bool ShowGeneratedDate { get; set; } = true;
+            public bool ShowStepTimestamps { get; set; } = false;
+            public bool ShowAction { get; set; } = false;
+            public bool ShowApplication { get; set; } = false;
+            public bool ShowWindow { get; set; } = false;
+            public bool ShowElement { get; set; } = false;
+            public bool ShowElementType { get; set; } = false;
+            public bool ShowMousePosition { get; set; } = false;
+
+            [JsonIgnore]
+            public bool IsDetailTableEmpty =>
+                !ShowAction && !ShowApplication && !ShowWindow &&
+                !ShowElement && !ShowElementType && !ShowMousePosition;
+        }
+
+        public class ObsidianSettings
+        {
+            public bool ShowSummary { get; set; } = true;
+            public bool ShowGeneratedDate { get; set; } = true;
+            public bool ShowStepTimestamps { get; set; } = false;
+            public bool ShowAction { get; set; } = false;
+            public bool ShowApplication { get; set; } = false;
+            public bool ShowWindow { get; set; } = false;
+            public bool ShowElement { get; set; } = false;
+            public bool ShowElementType { get; set; } = false;
+            public bool ShowMousePosition { get; set; } = false;
+
+            [JsonIgnore]
+            public bool IsDetailTableEmpty =>
+                !ShowAction && !ShowApplication && !ShowWindow &&
+                !ShowElement && !ShowElementType && !ShowMousePosition;
+        }
+
         public class ExportSettings
         {
             public HtmlSettings Html { get; set; } = new HtmlSettings();
             public MarkdownSettings Markdown { get; set; } = new MarkdownSettings();
+            public RtfSettings Rtf { get; set; } = new RtfSettings();
+            public OdtSettings Odt { get; set; } = new OdtSettings();
+            public ObsidianSettings Obsidian { get; set; } = new ObsidianSettings();
         }
     }
 

--- a/src/BetterStepsRecorder/Exporters/ObsidianExporter.cs
+++ b/src/BetterStepsRecorder/Exporters/ObsidianExporter.cs
@@ -14,6 +14,15 @@ namespace BetterStepsRecorder.Exporters
     /// </summary>
     public class ObsidianExporter : ExporterBase
     {
+        private static string FormatDuration(TimeSpan ts)
+        {
+            if (ts.TotalHours >= 1)
+                return $"{(int)ts.TotalHours}h {ts.Minutes:D2}m {ts.Seconds:D2}s";
+            if (ts.TotalMinutes >= 1)
+                return $"{ts.Minutes}m {ts.Seconds:D2}s";
+            return $"{ts.Seconds}s";
+        }
+
         /// <summary>
         /// Exports the current steps recording to an Obsidian vault
         /// </summary>
@@ -34,6 +43,15 @@ namespace BetterStepsRecorder.Exporters
         /// <param name="subfolderPath">Optional subfolder path within the vault</param>
         /// <returns>True if export was successful, false otherwise</returns>
         public bool ExportToObsidianVault(string vaultPath, string fileName, string subfolderPath = "")
+        {
+            var cfg = BSRSettings.Current.ExportOptions.Obsidian;
+            return ExportToObsidianVault(vaultPath, fileName, subfolderPath, cfg);
+        }
+
+        /// <summary>
+        /// Exports the current steps recording to an Obsidian vault using the supplied settings
+        /// </summary>
+        public bool ExportToObsidianVault(string vaultPath, string fileName, string subfolderPath, BSRSettings.ObsidianSettings cfg)
         {
             try
             {
@@ -64,6 +82,20 @@ namespace BetterStepsRecorder.Exporters
                     mdFilePath = Path.Combine(fullSubfolderPath, $"{fileName}.md");
                 }
 
+                int totalSteps = Program._recordEvents.Count;
+                string generated = DateTime.Now.ToString("dd MMM yyyy, HH:mm");
+
+                // Compute recording start/end/duration from event timestamps
+                DateTime? recordingStart = totalSteps > 0 ? Program._recordEvents[0].CreationTime : (DateTime?)null;
+                DateTime? recordingEnd = totalSteps > 0 ? Program._recordEvents[totalSteps - 1].CreationTime : (DateTime?)null;
+                TimeSpan totalDuration = (recordingStart.HasValue && recordingEnd.HasValue)
+                    ? recordingEnd.Value - recordingStart.Value
+                    : TimeSpan.Zero;
+
+                string startStr = recordingStart?.ToString("dd MMM yyyy, HH:mm:ss") ?? "—";
+                string endStr = recordingEnd?.ToString("HH:mm:ss") ?? "—";
+                string durationStr = totalSteps > 1 ? FormatDuration(totalDuration) : "—";
+
                 // Track used image filenames to avoid duplicates
                 HashSet<string> usedImageNames = new HashSet<string>();
 
@@ -71,15 +103,83 @@ namespace BetterStepsRecorder.Exporters
                 using (StreamWriter writer = new StreamWriter(mdFilePath))
                 {
                     // Add title (using the filename)
-                    //writer.WriteLine($"# {fileName}");
-                    //writer.WriteLine();
+                    writer.WriteLine($"# {fileName}");
+                    writer.WriteLine();
+
+                    // Generated date
+                    if (cfg.ShowGeneratedDate)
+                    {
+                        writer.WriteLine($"*Generated {generated}*");
+                        writer.WriteLine();
+                    }
+
+                    // Summary section
+                    if (cfg.ShowSummary)
+                    {
+                        writer.WriteLine("## Summary");
+                        writer.WriteLine();
+                        writer.WriteLine("| Property | Value |");
+                        writer.WriteLine("|----------|-------|");
+                        writer.WriteLine($"| Steps | {totalSteps} |");
+                        writer.WriteLine($"| Started | {startStr} |");
+                        writer.WriteLine($"| Finished | {endStr} |");
+                        writer.WriteLine($"| Duration | {durationStr} |");
+                        writer.WriteLine();
+                    }
+
+                    // Steps section
+                    writer.WriteLine("## Steps");
+                    writer.WriteLine();
 
                     // Add each step
+                    DateTime? prevTime = null;
                     foreach (var recordEvent in Program._recordEvents)
                     {
-                        // Write the step number and text
-                        writer.WriteLine($"## Step {recordEvent.Step}: {recordEvent._StepText}");
+                        string stepText = recordEvent._StepText ?? string.Empty;
+
+                        // Step header
+                        writer.WriteLine($"### Step {recordEvent.Step}");
                         writer.WriteLine();
+                        writer.WriteLine($"**{stepText}**");
+                        writer.WriteLine();
+
+                        // Timestamp
+                        if (cfg.ShowStepTimestamps)
+                        {
+                            string timeStr;
+                            if (prevTime.HasValue)
+                            {
+                                TimeSpan delta = recordEvent.CreationTime - prevTime.Value;
+                                timeStr = $"⏱️ {prevTime.Value:HH:mm:ss} → {recordEvent.CreationTime:HH:mm:ss} (+{FormatDuration(delta)})";
+                            }
+                            else
+                            {
+                                timeStr = $"⏱️ {recordEvent.CreationTime:HH:mm:ss}";
+                            }
+                            writer.WriteLine(timeStr);
+                            writer.WriteLine();
+                        }
+                        prevTime = recordEvent.CreationTime;
+
+                        // Detail table - only rendered when at least one detail option is on
+                        if (!cfg.IsDetailTableEmpty)
+                        {
+                            writer.WriteLine("| Detail | Value |");
+                            writer.WriteLine("|--------|-------|");
+                            if (cfg.ShowAction && !string.IsNullOrWhiteSpace(recordEvent.EventType))
+                                writer.WriteLine($"| Action | {recordEvent.EventType} |");
+                            if (cfg.ShowApplication && !string.IsNullOrWhiteSpace(recordEvent.ApplicationName))
+                                writer.WriteLine($"| Application | {recordEvent.ApplicationName} |");
+                            if (cfg.ShowWindow && !string.IsNullOrWhiteSpace(recordEvent.WindowTitle))
+                                writer.WriteLine($"| Window | {recordEvent.WindowTitle} |");
+                            if (cfg.ShowElement && !string.IsNullOrWhiteSpace(recordEvent.ElementName))
+                                writer.WriteLine($"| Element | {recordEvent.ElementName} |");
+                            if (cfg.ShowElementType && !string.IsNullOrWhiteSpace(recordEvent.ElementType))
+                                writer.WriteLine($"| Element Type | {recordEvent.ElementType} |");
+                            if (cfg.ShowMousePosition && (recordEvent.MouseCoordinates.X != 0 || recordEvent.MouseCoordinates.Y != 0))
+                                writer.WriteLine($"| Mouse Position | {recordEvent.MouseCoordinates.X}, {recordEvent.MouseCoordinates.Y} |");
+                            writer.WriteLine();
+                        }
 
                         // Process and save image if available
                         if (recordEvent.HasScreenshot)
@@ -97,22 +197,26 @@ namespace BetterStepsRecorder.Exporters
 
                             // Get the relative path for the image link
                             string relativeImagePath = GetRelativeImagePath(vaultPath, imageFolderPath, imageFileName);
-                            
+
                             // Add the image link to the markdown
                             writer.WriteLine($"![[{relativeImagePath}]]");
                             writer.WriteLine();
                         }
 
-                        // Add separator between steps
-                        writer.WriteLine("---");
-                        writer.WriteLine();
+                        // Add separator between steps (except after last step)
+                        if (recordEvent.Step < totalSteps)
+                        {
+                            writer.WriteLine("---");
+                            writer.WriteLine();
+                        }
                     }
-                    
+
                     // Add footer with link to GitHub
                     writer.WriteLine();
-                    
-                    writer.WriteLine("Generated with [Better Steps Recorder](https://github.com/Mentaleak/BetterStepsRecorder)");
-                    
+                    writer.WriteLine("---");
+                    writer.WriteLine();
+                    writer.WriteLine("*Generated with [Better Steps Recorder](https://github.com/Mentaleak/BetterStepsRecorder)*");
+
                 }
 
                 ShowExportSuccess(mdFilePath);

--- a/src/BetterStepsRecorder/Exporters/OdtExporter.cs
+++ b/src/BetterStepsRecorder/Exporters/OdtExporter.cs
@@ -16,6 +16,15 @@ namespace BetterStepsRecorder.Exporters
     /// </summary>
     public class OdtExporter : ExporterBase
     {
+        private static string FormatDuration(TimeSpan ts)
+        {
+            if (ts.TotalHours >= 1)
+                return $"{(int)ts.TotalHours}h {ts.Minutes:D2}m {ts.Seconds:D2}s";
+            if (ts.TotalMinutes >= 1)
+                return $"{ts.Minutes}m {ts.Seconds:D2}s";
+            return $"{ts.Seconds}s";
+        }
+
         /// <summary>
         /// Exports the current steps recording to ODT format
         /// </summary>
@@ -23,20 +32,29 @@ namespace BetterStepsRecorder.Exporters
         /// <returns>True if export was successful, false otherwise</returns>
         public override bool Export(string filePath)
         {
+            var cfg = BSRSettings.Current.ExportOptions.Odt;
+            return Export(filePath, cfg);
+        }
+
+        /// <summary>
+        /// Exports the current steps recording to ODT format using the supplied settings
+        /// </summary>
+        public bool Export(string filePath, BSRSettings.OdtSettings cfg)
+        {
             try
             {
                 EnsureDirectoryExists(filePath);
-                
+
                 // Create a temporary directory for ODT contents
                 string tempDir = Path.Combine(Path.GetTempPath(), "BSR_ODT_" + Guid.NewGuid().ToString());
                 Directory.CreateDirectory(tempDir);
-                
+
                 try
                 {
                     // Create ODT structure
                     Directory.CreateDirectory(Path.Combine(tempDir, "META-INF"));
                     Directory.CreateDirectory(Path.Combine(tempDir, "Pictures"));
-                    
+
                     // Create manifest file
                     CreateManifestFile(tempDir);
 
@@ -44,19 +62,19 @@ namespace BetterStepsRecorder.Exporters
                     var imageDimensions = SaveImages(tempDir);
 
                     // Create content files
-                    CreateContentFile(tempDir, imageDimensions);
+                    CreateContentFile(tempDir, imageDimensions, cfg);
                     CreateStylesFile(tempDir);
                     CreateMetaFile(tempDir);
 
                     // Create mimetype file
                     File.WriteAllText(Path.Combine(tempDir, "mimetype"), "application/vnd.oasis.opendocument.text");
-                    
+
                     // Create the ODT file (ZIP)
                     if (File.Exists(filePath))
                         File.Delete(filePath);
-                    
+
                     ZipFile.CreateFromDirectory(tempDir, filePath);
-                    
+
                     ShowExportSuccess(filePath);
                     return true;
                 }
@@ -131,10 +149,24 @@ namespace BetterStepsRecorder.Exporters
             }
         }
         
-        private void CreateContentFile(string tempDir, Dictionary<Guid, Size> imageDimensions)
+        private void CreateContentFile(string tempDir, Dictionary<Guid, Size> imageDimensions, BSRSettings.OdtSettings cfg)
         {
             string contentPath = Path.Combine(tempDir, "content.xml");
-            
+
+            int totalSteps = Program._recordEvents.Count;
+            string generated = DateTime.Now.ToString("dd MMM yyyy, HH:mm");
+
+            // Compute recording start/end/duration from event timestamps
+            DateTime? recordingStart = totalSteps > 0 ? Program._recordEvents[0].CreationTime : (DateTime?)null;
+            DateTime? recordingEnd = totalSteps > 0 ? Program._recordEvents[totalSteps - 1].CreationTime : (DateTime?)null;
+            TimeSpan totalDuration = (recordingStart.HasValue && recordingEnd.HasValue)
+                ? recordingEnd.Value - recordingStart.Value
+                : TimeSpan.Zero;
+
+            string startStr = recordingStart?.ToString("dd MMM yyyy, HH:mm:ss") ?? "—";
+            string endStr = recordingEnd?.ToString("HH:mm:ss") ?? "—";
+            string durationStr = totalSteps > 1 ? FormatDuration(totalDuration) : "—";
+
             XmlWriterSettings settings = new XmlWriterSettings { 
                 Indent = true,
                 IndentChars = "  "
@@ -263,11 +295,11 @@ namespace BetterStepsRecorder.Exporters
                 // Document content
                 writer.WriteStartElement("body", "urn:oasis:names:tc:opendocument:xmlns:office:1.0");
                 writer.WriteStartElement("text", "urn:oasis:names:tc:opendocument:xmlns:office:1.0");
-                
+
                 // Title
                 writer.WriteStartElement("p", "urn:oasis:names:tc:opendocument:xmlns:text:1.0");
                 writer.WriteAttributeString("style-name", "urn:oasis:names:tc:opendocument:xmlns:text:1.0", "Title");
-                
+
                 // Use the filename if available
                 string title = "Steps Recording";
                 if (Program.zip?.ZipFilePath != null)
@@ -276,8 +308,45 @@ namespace BetterStepsRecorder.Exporters
                 }
                 writer.WriteString(title);
                 writer.WriteEndElement(); // text:p
-                
+
+                // Generated date
+                if (cfg.ShowGeneratedDate)
+                {
+                    writer.WriteStartElement("p", "urn:oasis:names:tc:opendocument:xmlns:text:1.0");
+                    writer.WriteAttributeString("style-name", "urn:oasis:names:tc:opendocument:xmlns:text:1.0", "Normal");
+                    writer.WriteString($"Generated {generated}");
+                    writer.WriteEndElement(); // text:p
+                }
+
+                // Summary table
+                if (cfg.ShowSummary)
+                {
+                    writer.WriteStartElement("table", "urn:oasis:names:tc:opendocument:xmlns:table:1.0");
+                    writer.WriteAttributeString("name", "urn:oasis:names:tc:opendocument:xmlns:table:1.0", "SummaryTable");
+
+                    // Define columns
+                    writer.WriteStartElement("table-column", "urn:oasis:names:tc:opendocument:xmlns:table:1.0");
+                    writer.WriteEndElement();
+                    writer.WriteStartElement("table-column", "urn:oasis:names:tc:opendocument:xmlns:table:1.0");
+                    writer.WriteEndElement();
+
+                    // Add rows
+                    WriteTableRow(writer, "Steps", totalSteps.ToString());
+                    WriteTableRow(writer, "Started", startStr);
+                    WriteTableRow(writer, "Finished", endStr);
+                    WriteTableRow(writer, "Duration", durationStr);
+
+                    writer.WriteEndElement(); // table:table
+
+                    // Empty paragraph for spacing
+                    writer.WriteStartElement("p", "urn:oasis:names:tc:opendocument:xmlns:text:1.0");
+                    writer.WriteAttributeString("style-name", "urn:oasis:names:tc:opendocument:xmlns:text:1.0", "Normal");
+                    writer.WriteString(" ");
+                    writer.WriteEndElement(); // text:p
+                }
+
                 // Add each step
+                DateTime? prevTime = null;
                 foreach (var recordEvent in Program._recordEvents)
                 {
                     // Step header
@@ -285,7 +354,62 @@ namespace BetterStepsRecorder.Exporters
                     writer.WriteAttributeString("style-name", "urn:oasis:names:tc:opendocument:xmlns:text:1.0", "StepHeader");
                     writer.WriteString($"Step {recordEvent.Step}: {recordEvent._StepText}");
                     writer.WriteEndElement(); // text:p
-                    
+
+                    // Timestamp
+                    if (cfg.ShowStepTimestamps)
+                    {
+                        writer.WriteStartElement("p", "urn:oasis:names:tc:opendocument:xmlns:text:1.0");
+                        writer.WriteAttributeString("style-name", "urn:oasis:names:tc:opendocument:xmlns:text:1.0", "Normal");
+                        string timeStr;
+                        if (prevTime.HasValue)
+                        {
+                            TimeSpan delta = recordEvent.CreationTime - prevTime.Value;
+                            timeStr = $"{prevTime.Value:HH:mm:ss} → {recordEvent.CreationTime:HH:mm:ss} (+{FormatDuration(delta)})";
+                        }
+                        else
+                        {
+                            timeStr = recordEvent.CreationTime.ToString("HH:mm:ss");
+                        }
+                        writer.WriteString(timeStr);
+                        writer.WriteEndElement(); // text:p
+                    }
+                    prevTime = recordEvent.CreationTime;
+
+                    // Detail table - only rendered when at least one detail option is on
+                    if (!cfg.IsDetailTableEmpty)
+                    {
+                        writer.WriteStartElement("table", "urn:oasis:names:tc:opendocument:xmlns:table:1.0");
+                        writer.WriteAttributeString("name", "urn:oasis:names:tc:opendocument:xmlns:table:1.0", $"DetailTable{recordEvent.Step}");
+
+                        // Define columns
+                        writer.WriteStartElement("table-column", "urn:oasis:names:tc:opendocument:xmlns:table:1.0");
+                        writer.WriteEndElement();
+                        writer.WriteStartElement("table-column", "urn:oasis:names:tc:opendocument:xmlns:table:1.0");
+                        writer.WriteEndElement();
+
+                        // Add rows
+                        if (cfg.ShowAction && !string.IsNullOrWhiteSpace(recordEvent.EventType))
+                            WriteTableRow(writer, "Action", recordEvent.EventType);
+                        if (cfg.ShowApplication && !string.IsNullOrWhiteSpace(recordEvent.ApplicationName))
+                            WriteTableRow(writer, "Application", recordEvent.ApplicationName);
+                        if (cfg.ShowWindow && !string.IsNullOrWhiteSpace(recordEvent.WindowTitle))
+                            WriteTableRow(writer, "Window", recordEvent.WindowTitle);
+                        if (cfg.ShowElement && !string.IsNullOrWhiteSpace(recordEvent.ElementName))
+                            WriteTableRow(writer, "Element", recordEvent.ElementName);
+                        if (cfg.ShowElementType && !string.IsNullOrWhiteSpace(recordEvent.ElementType))
+                            WriteTableRow(writer, "Element Type", recordEvent.ElementType);
+                        if (cfg.ShowMousePosition && (recordEvent.MouseCoordinates.X != 0 || recordEvent.MouseCoordinates.Y != 0))
+                            WriteTableRow(writer, "Mouse Position", $"{recordEvent.MouseCoordinates.X}, {recordEvent.MouseCoordinates.Y}");
+
+                        writer.WriteEndElement(); // table:table
+
+                        // Empty paragraph for spacing
+                        writer.WriteStartElement("p", "urn:oasis:names:tc:opendocument:xmlns:text:1.0");
+                        writer.WriteAttributeString("style-name", "urn:oasis:names:tc:opendocument:xmlns:text:1.0", "Normal");
+                        writer.WriteString(" ");
+                        writer.WriteEndElement(); // text:p
+                    }
+
                     /* Add description text if there is any (split by line breaks)
                     if (!string.IsNullOrEmpty(recordEvent._StepText))
                     {
@@ -557,6 +681,29 @@ namespace BetterStepsRecorder.Exporters
                 return new Size(800, 600); // Default size if we can't determine actual size
             }
         }
-        
+
+        private void WriteTableRow(XmlWriter writer, string label, string value)
+        {
+            writer.WriteStartElement("table-row", "urn:oasis:names:tc:opendocument:xmlns:table:1.0");
+
+            // First cell (label)
+            writer.WriteStartElement("table-cell", "urn:oasis:names:tc:opendocument:xmlns:table:1.0");
+            writer.WriteStartElement("p", "urn:oasis:names:tc:opendocument:xmlns:text:1.0");
+            writer.WriteAttributeString("style-name", "urn:oasis:names:tc:opendocument:xmlns:text:1.0", "Normal");
+            writer.WriteString(label);
+            writer.WriteEndElement(); // text:p
+            writer.WriteEndElement(); // table:table-cell
+
+            // Second cell (value)
+            writer.WriteStartElement("table-cell", "urn:oasis:names:tc:opendocument:xmlns:table:1.0");
+            writer.WriteStartElement("p", "urn:oasis:names:tc:opendocument:xmlns:text:1.0");
+            writer.WriteAttributeString("style-name", "urn:oasis:names:tc:opendocument:xmlns:text:1.0", "Normal");
+            writer.WriteString(value);
+            writer.WriteEndElement(); // text:p
+            writer.WriteEndElement(); // table:table-cell
+
+            writer.WriteEndElement(); // table:table-row
+        }
+
     }
 }

--- a/src/BetterStepsRecorder/Exporters/RtfExporter.cs
+++ b/src/BetterStepsRecorder/Exporters/RtfExporter.cs
@@ -12,6 +12,15 @@ namespace BetterStepsRecorder.Exporters
     /// </summary>
     public class RtfExporter : ExporterBase
     {
+        private static string FormatDuration(TimeSpan ts)
+        {
+            if (ts.TotalHours >= 1)
+                return $"{(int)ts.TotalHours}h {ts.Minutes:D2}m {ts.Seconds:D2}s";
+            if (ts.TotalMinutes >= 1)
+                return $"{ts.Minutes}m {ts.Seconds:D2}s";
+            return $"{ts.Seconds}s";
+        }
+
         /// <summary>
         /// Exports the current steps recording to RTF format
         /// </summary>
@@ -19,17 +28,43 @@ namespace BetterStepsRecorder.Exporters
         /// <returns>True if export was successful, false otherwise</returns>
         public override bool Export(string filePath)
         {
+            var cfg = BSRSettings.Current.ExportOptions.Rtf;
+            return Export(filePath, cfg);
+        }
+
+        /// <summary>
+        /// Exports the current steps recording to RTF format using the supplied settings
+        /// </summary>
+        public bool Export(string filePath, BSRSettings.RtfSettings cfg)
+        {
             try
             {
                 EnsureDirectoryExists(filePath);
-                
+
                 // Get the filename without extension to use as title
                 string title = Path.GetFileNameWithoutExtension(filePath);
-                
+
+                int totalSteps = Program._recordEvents.Count;
+                string generated = DateTime.Now.ToString("dd MMM yyyy, HH:mm");
+
+                // Compute recording start/end/duration from event timestamps
+                DateTime? recordingStart = totalSteps > 0 ? Program._recordEvents[0].CreationTime : (DateTime?)null;
+                DateTime? recordingEnd = totalSteps > 0 ? Program._recordEvents[totalSteps - 1].CreationTime : (DateTime?)null;
+                TimeSpan totalDuration = (recordingStart.HasValue && recordingEnd.HasValue)
+                    ? recordingEnd.Value - recordingStart.Value
+                    : TimeSpan.Zero;
+
+                string startStr = recordingStart?.ToString("dd MMM yyyy, HH:mm:ss") ?? "—";
+                string endStr = recordingEnd?.ToString("HH:mm:ss") ?? "—";
+                string durationStr = totalSteps > 1 ? FormatDuration(totalDuration) : "—";
+
                 using (RichTextBox rtfBox = new RichTextBox())
                 using (var fontBody     = new Font("Segoe UI", 10))
                 using (var fontTitle    = new Font("Segoe UI", 16, FontStyle.Bold))
+                using (var fontMeta     = new Font("Segoe UI", 9))
                 using (var fontStep     = new Font("Segoe UI", 12, FontStyle.Bold))
+                using (var fontDetail   = new Font("Segoe UI", 9))
+                using (var fontDetailLabel = new Font("Segoe UI", 9, FontStyle.Bold))
                 using (var fontSep      = new Font("Segoe UI", 9))
                 using (var fontFooter   = new Font("Segoe UI", 8))
                 using (var fontLink     = new Font("Segoe UI", 8, FontStyle.Underline))
@@ -39,29 +74,107 @@ namespace BetterStepsRecorder.Exporters
 
                     // Add title using the filename
                     rtfBox.SelectionFont = fontTitle;
-                    rtfBox.AppendText($"{title}\n\n");
+                    rtfBox.AppendText($"{title}\n");
+
+                    // Add generated date
+                    if (cfg.ShowGeneratedDate)
+                    {
+                        rtfBox.SelectionFont = fontMeta;
+                        rtfBox.SelectionColor = Color.Gray;
+                        rtfBox.AppendText($"Generated {generated}\n");
+                        rtfBox.SelectionColor = rtfBox.ForeColor;
+                    }
+
+                    rtfBox.AppendText("\n");
+
+                    // Add summary section
+                    if (cfg.ShowSummary)
+                    {
+                        rtfBox.SelectionFont = fontDetailLabel;
+                        rtfBox.AppendText("Summary\n");
+                        rtfBox.SelectionFont = fontDetail;
+                        rtfBox.AppendText($"Steps: {totalSteps}\n");
+                        rtfBox.AppendText($"Started: {startStr}\n");
+                        rtfBox.AppendText($"Finished: {endStr}\n");
+                        rtfBox.AppendText($"Duration: {durationStr}\n");
+                        rtfBox.AppendText("\n");
+                    }
 
                     // Add each step
+                    DateTime? prevTime = null;
                     foreach (var recordEvent in Program._recordEvents)
                     {
                         // Add step header
                         rtfBox.SelectionFont = fontStep;
                         rtfBox.AppendText($"Step {recordEvent.Step}: {recordEvent._StepText}\n");
 
-                        /* Add element details if available
-                        if (!string.IsNullOrEmpty(recordEvent.ElementName))
+                        // Add timestamp
+                        if (cfg.ShowStepTimestamps)
                         {
-                            rtfBox.SelectionFont = new Font("Segoe UI", 9);
-                            rtfBox.AppendText($"Element: {recordEvent.ElementName}\n");
-
-                            // Get automation ID if available
-                            string automationId = RecordEvent.GetAutomationId(recordEvent.UIElement);
-                            if (!string.IsNullOrEmpty(automationId))
+                            rtfBox.SelectionFont = fontMeta;
+                            rtfBox.SelectionColor = Color.Gray;
+                            string timeStr;
+                            if (prevTime.HasValue)
                             {
-                                rtfBox.AppendText($"Automation ID: {automationId}\n");
+                                TimeSpan delta = recordEvent.CreationTime - prevTime.Value;
+                                timeStr = $"{prevTime.Value:HH:mm:ss} → {recordEvent.CreationTime:HH:mm:ss} (+{FormatDuration(delta)})";
+                            }
+                            else
+                            {
+                                timeStr = recordEvent.CreationTime.ToString("HH:mm:ss");
+                            }
+                            rtfBox.AppendText($"{timeStr}\n");
+                            rtfBox.SelectionColor = rtfBox.ForeColor;
+                        }
+                        prevTime = recordEvent.CreationTime;
+
+                        // Add detail strip - only if at least one detail option is on
+                        if (!cfg.IsDetailStripEmpty)
+                        {
+                            rtfBox.AppendText("\n");
+                            if (cfg.ShowAction && !string.IsNullOrWhiteSpace(recordEvent.EventType))
+                            {
+                                rtfBox.SelectionFont = fontDetailLabel;
+                                rtfBox.AppendText("Action: ");
+                                rtfBox.SelectionFont = fontDetail;
+                                rtfBox.AppendText($"{recordEvent.EventType}\n");
+                            }
+                            if (cfg.ShowApplication && !string.IsNullOrWhiteSpace(recordEvent.ApplicationName))
+                            {
+                                rtfBox.SelectionFont = fontDetailLabel;
+                                rtfBox.AppendText("Application: ");
+                                rtfBox.SelectionFont = fontDetail;
+                                rtfBox.AppendText($"{recordEvent.ApplicationName}\n");
+                            }
+                            if (cfg.ShowWindow && !string.IsNullOrWhiteSpace(recordEvent.WindowTitle))
+                            {
+                                rtfBox.SelectionFont = fontDetailLabel;
+                                rtfBox.AppendText("Window: ");
+                                rtfBox.SelectionFont = fontDetail;
+                                rtfBox.AppendText($"{recordEvent.WindowTitle}\n");
+                            }
+                            if (cfg.ShowElement && !string.IsNullOrWhiteSpace(recordEvent.ElementName))
+                            {
+                                rtfBox.SelectionFont = fontDetailLabel;
+                                rtfBox.AppendText("Element: ");
+                                rtfBox.SelectionFont = fontDetail;
+                                rtfBox.AppendText($"{recordEvent.ElementName}\n");
+                            }
+                            if (cfg.ShowElementType && !string.IsNullOrWhiteSpace(recordEvent.ElementType))
+                            {
+                                rtfBox.SelectionFont = fontDetailLabel;
+                                rtfBox.AppendText("Element Type: ");
+                                rtfBox.SelectionFont = fontDetail;
+                                rtfBox.AppendText($"{recordEvent.ElementType}\n");
+                            }
+                            if (cfg.ShowMousePosition && (recordEvent.MouseCoordinates.X != 0 || recordEvent.MouseCoordinates.Y != 0))
+                            {
+                                rtfBox.SelectionFont = fontDetailLabel;
+                                rtfBox.AppendText("Mouse Position: ");
+                                rtfBox.SelectionFont = fontDetail;
+                                rtfBox.AppendText($"{recordEvent.MouseCoordinates.X}, {recordEvent.MouseCoordinates.Y}\n");
                             }
                         }
-                        */
 
                         // Add screenshot if available
                         if (recordEvent.HasScreenshot)
@@ -103,7 +216,7 @@ namespace BetterStepsRecorder.Exporters
                     // Save the RTF file
                     rtfBox.SaveFile(filePath);
                 }
-                
+
                 ShowExportSuccess(filePath);
                 return true;
             }

--- a/src/BetterStepsRecorder/UI/Settings/Export/ExportObsidian.Designer.cs
+++ b/src/BetterStepsRecorder/UI/Settings/Export/ExportObsidian.Designer.cs
@@ -1,0 +1,214 @@
+namespace BetterStepsRecorder.UI.Settings
+{
+    partial class ExportObsidian
+    {
+        /// <summary> 
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary> 
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Component Designer generated code
+
+        /// <summary> 
+        /// Required method for Designer support - do not modify 
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            lblNote = new Label();
+            lblHeader = new Label();
+            chkSummary = new CheckBox();
+            chkGeneratedDate = new CheckBox();
+            lblPerStep = new Label();
+            chkStepTimestamps = new CheckBox();
+            lblDetailTable = new Label();
+            chkAction = new CheckBox();
+            chkApplication = new CheckBox();
+            chkWindow = new CheckBox();
+            chkElement = new CheckBox();
+            chkElementType = new CheckBox();
+            chkMousePosition = new CheckBox();
+            SuspendLayout();
+            // 
+            // lblNote
+            // 
+            lblNote.ForeColor = SystemColors.GrayText;
+            lblNote.Location = new Point(3, 12);
+            lblNote.Name = "lblNote";
+            lblNote.Size = new Size(450, 46);
+            lblNote.TabIndex = 0;
+            lblNote.Text = "Choose which metadata to include in the Obsidian export.\r\nImages are saved to an 'images' subfolder and linked in the .md file.";
+            // 
+            // lblHeader
+            // 
+            lblHeader.AutoSize = true;
+            lblHeader.Font = new Font("Segoe UI", 8.5F, FontStyle.Bold);
+            lblHeader.Location = new Point(3, 70);
+            lblHeader.Name = "lblHeader";
+            lblHeader.Size = new Size(53, 19);
+            lblHeader.TabIndex = 1;
+            lblHeader.Text = "Header";
+            // 
+            // chkSummary
+            // 
+            chkSummary.AutoSize = true;
+            chkSummary.Location = new Point(20, 95);
+            chkSummary.Name = "chkSummary";
+            chkSummary.Size = new Size(343, 24);
+            chkSummary.TabIndex = 2;
+            chkSummary.Text = "Summary table (Steps / Start / End / Duration)";
+            chkSummary.UseVisualStyleBackColor = true;
+            // 
+            // chkGeneratedDate
+            // 
+            chkGeneratedDate.AutoSize = true;
+            chkGeneratedDate.Location = new Point(20, 119);
+            chkGeneratedDate.Name = "chkGeneratedDate";
+            chkGeneratedDate.Size = new Size(137, 24);
+            chkGeneratedDate.TabIndex = 3;
+            chkGeneratedDate.Text = "Generated date";
+            chkGeneratedDate.UseVisualStyleBackColor = true;
+            // 
+            // lblPerStep
+            // 
+            lblPerStep.AutoSize = true;
+            lblPerStep.Font = new Font("Segoe UI", 8.5F, FontStyle.Bold);
+            lblPerStep.Location = new Point(3, 155);
+            lblPerStep.Name = "lblPerStep";
+            lblPerStep.Size = new Size(65, 19);
+            lblPerStep.TabIndex = 4;
+            lblPerStep.Text = "Per-Step";
+            // 
+            // chkStepTimestamps
+            // 
+            chkStepTimestamps.AutoSize = true;
+            chkStepTimestamps.Location = new Point(20, 180);
+            chkStepTimestamps.Name = "chkStepTimestamps";
+            chkStepTimestamps.Size = new Size(147, 24);
+            chkStepTimestamps.TabIndex = 5;
+            chkStepTimestamps.Text = "Step timestamps";
+            chkStepTimestamps.UseVisualStyleBackColor = true;
+            // 
+            // lblDetailTable
+            // 
+            lblDetailTable.AutoSize = true;
+            lblDetailTable.Font = new Font("Segoe UI", 8.5F, FontStyle.Bold);
+            lblDetailTable.Location = new Point(3, 216);
+            lblDetailTable.Name = "lblDetailTable";
+            lblDetailTable.Size = new Size(88, 19);
+            lblDetailTable.TabIndex = 6;
+            lblDetailTable.Text = "Detail Table";
+            // 
+            // chkAction
+            // 
+            chkAction.AutoSize = true;
+            chkAction.Location = new Point(20, 241);
+            chkAction.Name = "chkAction";
+            chkAction.Size = new Size(75, 24);
+            chkAction.TabIndex = 7;
+            chkAction.Text = "Action";
+            chkAction.UseVisualStyleBackColor = true;
+            // 
+            // chkApplication
+            // 
+            chkApplication.AutoSize = true;
+            chkApplication.Location = new Point(20, 265);
+            chkApplication.Name = "chkApplication";
+            chkApplication.Size = new Size(110, 24);
+            chkApplication.TabIndex = 8;
+            chkApplication.Text = "Application";
+            chkApplication.UseVisualStyleBackColor = true;
+            // 
+            // chkWindow
+            // 
+            chkWindow.AutoSize = true;
+            chkWindow.Location = new Point(20, 289);
+            chkWindow.Name = "chkWindow";
+            chkWindow.Size = new Size(87, 24);
+            chkWindow.TabIndex = 9;
+            chkWindow.Text = "Window";
+            chkWindow.UseVisualStyleBackColor = true;
+            // 
+            // chkElement
+            // 
+            chkElement.AutoSize = true;
+            chkElement.Location = new Point(20, 313);
+            chkElement.Name = "chkElement";
+            chkElement.Size = new Size(86, 24);
+            chkElement.TabIndex = 10;
+            chkElement.Text = "Element";
+            chkElement.UseVisualStyleBackColor = true;
+            // 
+            // chkElementType
+            // 
+            chkElementType.AutoSize = true;
+            chkElementType.Location = new Point(20, 337);
+            chkElementType.Name = "chkElementType";
+            chkElementType.Size = new Size(121, 24);
+            chkElementType.TabIndex = 11;
+            chkElementType.Text = "Element Type";
+            chkElementType.UseVisualStyleBackColor = true;
+            // 
+            // chkMousePosition
+            // 
+            chkMousePosition.AutoSize = true;
+            chkMousePosition.Location = new Point(20, 361);
+            chkMousePosition.Name = "chkMousePosition";
+            chkMousePosition.Size = new Size(133, 24);
+            chkMousePosition.TabIndex = 12;
+            chkMousePosition.Text = "Mouse Position";
+            chkMousePosition.UseVisualStyleBackColor = true;
+            // 
+            // ExportObsidian
+            // 
+            AutoScaleDimensions = new SizeF(8F, 20F);
+            AutoScaleMode = AutoScaleMode.Font;
+            Controls.Add(chkMousePosition);
+            Controls.Add(chkElementType);
+            Controls.Add(chkElement);
+            Controls.Add(chkWindow);
+            Controls.Add(chkApplication);
+            Controls.Add(chkAction);
+            Controls.Add(lblDetailTable);
+            Controls.Add(chkStepTimestamps);
+            Controls.Add(lblPerStep);
+            Controls.Add(chkGeneratedDate);
+            Controls.Add(chkSummary);
+            Controls.Add(lblHeader);
+            Controls.Add(lblNote);
+            Name = "ExportObsidian";
+            Size = new Size(472, 400);
+            ResumeLayout(false);
+            PerformLayout();
+        }
+
+        #endregion
+
+        private Label lblNote;
+        private Label lblHeader;
+        private CheckBox chkSummary;
+        private CheckBox chkGeneratedDate;
+        private Label lblPerStep;
+        private CheckBox chkStepTimestamps;
+        private Label lblDetailTable;
+        private CheckBox chkAction;
+        private CheckBox chkApplication;
+        private CheckBox chkWindow;
+        private CheckBox chkElement;
+        private CheckBox chkElementType;
+        private CheckBox chkMousePosition;
+    }
+}

--- a/src/BetterStepsRecorder/UI/Settings/Export/ExportObsidian.cs
+++ b/src/BetterStepsRecorder/UI/Settings/Export/ExportObsidian.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Drawing;
+using System.Text;
+using System.Windows.Forms;
+
+namespace BetterStepsRecorder.UI.Settings
+{
+    public partial class ExportObsidian : UserControl
+    {
+        public ExportObsidian()
+        {
+            InitializeComponent();
+            LoadSettings();
+
+            // Auto-save when any checkbox changes
+            chkSummary.CheckedChanged += Checkbox_CheckedChanged;
+            chkGeneratedDate.CheckedChanged += Checkbox_CheckedChanged;
+            chkStepTimestamps.CheckedChanged += Checkbox_CheckedChanged;
+            chkAction.CheckedChanged += Checkbox_CheckedChanged;
+            chkApplication.CheckedChanged += Checkbox_CheckedChanged;
+            chkWindow.CheckedChanged += Checkbox_CheckedChanged;
+            chkElement.CheckedChanged += Checkbox_CheckedChanged;
+            chkElementType.CheckedChanged += Checkbox_CheckedChanged;
+            chkMousePosition.CheckedChanged += Checkbox_CheckedChanged;
+        }
+
+        private void LoadSettings()
+        {
+            var obsidianSettings = BSRSettings.Current.ExportOptions.Obsidian;
+
+            chkSummary.Checked = obsidianSettings.ShowSummary;
+            chkGeneratedDate.Checked = obsidianSettings.ShowGeneratedDate;
+            chkStepTimestamps.Checked = obsidianSettings.ShowStepTimestamps;
+            chkAction.Checked = obsidianSettings.ShowAction;
+            chkApplication.Checked = obsidianSettings.ShowApplication;
+            chkWindow.Checked = obsidianSettings.ShowWindow;
+            chkElement.Checked = obsidianSettings.ShowElement;
+            chkElementType.Checked = obsidianSettings.ShowElementType;
+            chkMousePosition.Checked = obsidianSettings.ShowMousePosition;
+        }
+
+        private void Checkbox_CheckedChanged(object sender, EventArgs e)
+        {
+            SaveSettings();
+        }
+
+        private void SaveSettings()
+        {
+            var obsidianSettings = BSRSettings.Current.ExportOptions.Obsidian;
+
+            obsidianSettings.ShowSummary = chkSummary.Checked;
+            obsidianSettings.ShowGeneratedDate = chkGeneratedDate.Checked;
+            obsidianSettings.ShowStepTimestamps = chkStepTimestamps.Checked;
+            obsidianSettings.ShowAction = chkAction.Checked;
+            obsidianSettings.ShowApplication = chkApplication.Checked;
+            obsidianSettings.ShowWindow = chkWindow.Checked;
+            obsidianSettings.ShowElement = chkElement.Checked;
+            obsidianSettings.ShowElementType = chkElementType.Checked;
+            obsidianSettings.ShowMousePosition = chkMousePosition.Checked;
+
+            BSRSettings.Current.Save();
+        }
+    }
+}

--- a/src/BetterStepsRecorder/UI/Settings/Export/ExportOdt.Designer.cs
+++ b/src/BetterStepsRecorder/UI/Settings/Export/ExportOdt.Designer.cs
@@ -1,0 +1,214 @@
+namespace BetterStepsRecorder.UI.Settings
+{
+    partial class ExportOdt
+    {
+        /// <summary> 
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary> 
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Component Designer generated code
+
+        /// <summary> 
+        /// Required method for Designer support - do not modify 
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            lblNote = new Label();
+            lblHeader = new Label();
+            chkSummary = new CheckBox();
+            chkGeneratedDate = new CheckBox();
+            lblPerStep = new Label();
+            chkStepTimestamps = new CheckBox();
+            lblDetailTable = new Label();
+            chkAction = new CheckBox();
+            chkApplication = new CheckBox();
+            chkWindow = new CheckBox();
+            chkElement = new CheckBox();
+            chkElementType = new CheckBox();
+            chkMousePosition = new CheckBox();
+            SuspendLayout();
+            // 
+            // lblNote
+            // 
+            lblNote.ForeColor = SystemColors.GrayText;
+            lblNote.Location = new Point(3, 12);
+            lblNote.Name = "lblNote";
+            lblNote.Size = new Size(450, 46);
+            lblNote.TabIndex = 0;
+            lblNote.Text = "Choose which metadata to include in the ODT export.\r\nThe step description and screenshot are always included.";
+            // 
+            // lblHeader
+            // 
+            lblHeader.AutoSize = true;
+            lblHeader.Font = new Font("Segoe UI", 8.5F, FontStyle.Bold);
+            lblHeader.Location = new Point(3, 70);
+            lblHeader.Name = "lblHeader";
+            lblHeader.Size = new Size(53, 19);
+            lblHeader.TabIndex = 1;
+            lblHeader.Text = "Header";
+            // 
+            // chkSummary
+            // 
+            chkSummary.AutoSize = true;
+            chkSummary.Location = new Point(20, 95);
+            chkSummary.Name = "chkSummary";
+            chkSummary.Size = new Size(343, 24);
+            chkSummary.TabIndex = 2;
+            chkSummary.Text = "Summary table (Steps / Start / End / Duration)";
+            chkSummary.UseVisualStyleBackColor = true;
+            // 
+            // chkGeneratedDate
+            // 
+            chkGeneratedDate.AutoSize = true;
+            chkGeneratedDate.Location = new Point(20, 119);
+            chkGeneratedDate.Name = "chkGeneratedDate";
+            chkGeneratedDate.Size = new Size(137, 24);
+            chkGeneratedDate.TabIndex = 3;
+            chkGeneratedDate.Text = "Generated date";
+            chkGeneratedDate.UseVisualStyleBackColor = true;
+            // 
+            // lblPerStep
+            // 
+            lblPerStep.AutoSize = true;
+            lblPerStep.Font = new Font("Segoe UI", 8.5F, FontStyle.Bold);
+            lblPerStep.Location = new Point(3, 155);
+            lblPerStep.Name = "lblPerStep";
+            lblPerStep.Size = new Size(65, 19);
+            lblPerStep.TabIndex = 4;
+            lblPerStep.Text = "Per-Step";
+            // 
+            // chkStepTimestamps
+            // 
+            chkStepTimestamps.AutoSize = true;
+            chkStepTimestamps.Location = new Point(20, 180);
+            chkStepTimestamps.Name = "chkStepTimestamps";
+            chkStepTimestamps.Size = new Size(147, 24);
+            chkStepTimestamps.TabIndex = 5;
+            chkStepTimestamps.Text = "Step timestamps";
+            chkStepTimestamps.UseVisualStyleBackColor = true;
+            // 
+            // lblDetailTable
+            // 
+            lblDetailTable.AutoSize = true;
+            lblDetailTable.Font = new Font("Segoe UI", 8.5F, FontStyle.Bold);
+            lblDetailTable.Location = new Point(3, 216);
+            lblDetailTable.Name = "lblDetailTable";
+            lblDetailTable.Size = new Size(88, 19);
+            lblDetailTable.TabIndex = 6;
+            lblDetailTable.Text = "Detail Table";
+            // 
+            // chkAction
+            // 
+            chkAction.AutoSize = true;
+            chkAction.Location = new Point(20, 241);
+            chkAction.Name = "chkAction";
+            chkAction.Size = new Size(75, 24);
+            chkAction.TabIndex = 7;
+            chkAction.Text = "Action";
+            chkAction.UseVisualStyleBackColor = true;
+            // 
+            // chkApplication
+            // 
+            chkApplication.AutoSize = true;
+            chkApplication.Location = new Point(20, 265);
+            chkApplication.Name = "chkApplication";
+            chkApplication.Size = new Size(110, 24);
+            chkApplication.TabIndex = 8;
+            chkApplication.Text = "Application";
+            chkApplication.UseVisualStyleBackColor = true;
+            // 
+            // chkWindow
+            // 
+            chkWindow.AutoSize = true;
+            chkWindow.Location = new Point(20, 289);
+            chkWindow.Name = "chkWindow";
+            chkWindow.Size = new Size(87, 24);
+            chkWindow.TabIndex = 9;
+            chkWindow.Text = "Window";
+            chkWindow.UseVisualStyleBackColor = true;
+            // 
+            // chkElement
+            // 
+            chkElement.AutoSize = true;
+            chkElement.Location = new Point(20, 313);
+            chkElement.Name = "chkElement";
+            chkElement.Size = new Size(86, 24);
+            chkElement.TabIndex = 10;
+            chkElement.Text = "Element";
+            chkElement.UseVisualStyleBackColor = true;
+            // 
+            // chkElementType
+            // 
+            chkElementType.AutoSize = true;
+            chkElementType.Location = new Point(20, 337);
+            chkElementType.Name = "chkElementType";
+            chkElementType.Size = new Size(121, 24);
+            chkElementType.TabIndex = 11;
+            chkElementType.Text = "Element Type";
+            chkElementType.UseVisualStyleBackColor = true;
+            // 
+            // chkMousePosition
+            // 
+            chkMousePosition.AutoSize = true;
+            chkMousePosition.Location = new Point(20, 361);
+            chkMousePosition.Name = "chkMousePosition";
+            chkMousePosition.Size = new Size(133, 24);
+            chkMousePosition.TabIndex = 12;
+            chkMousePosition.Text = "Mouse Position";
+            chkMousePosition.UseVisualStyleBackColor = true;
+            // 
+            // ExportOdt
+            // 
+            AutoScaleDimensions = new SizeF(8F, 20F);
+            AutoScaleMode = AutoScaleMode.Font;
+            Controls.Add(chkMousePosition);
+            Controls.Add(chkElementType);
+            Controls.Add(chkElement);
+            Controls.Add(chkWindow);
+            Controls.Add(chkApplication);
+            Controls.Add(chkAction);
+            Controls.Add(lblDetailTable);
+            Controls.Add(chkStepTimestamps);
+            Controls.Add(lblPerStep);
+            Controls.Add(chkGeneratedDate);
+            Controls.Add(chkSummary);
+            Controls.Add(lblHeader);
+            Controls.Add(lblNote);
+            Name = "ExportOdt";
+            Size = new Size(472, 400);
+            ResumeLayout(false);
+            PerformLayout();
+        }
+
+        #endregion
+
+        private Label lblNote;
+        private Label lblHeader;
+        private CheckBox chkSummary;
+        private CheckBox chkGeneratedDate;
+        private Label lblPerStep;
+        private CheckBox chkStepTimestamps;
+        private Label lblDetailTable;
+        private CheckBox chkAction;
+        private CheckBox chkApplication;
+        private CheckBox chkWindow;
+        private CheckBox chkElement;
+        private CheckBox chkElementType;
+        private CheckBox chkMousePosition;
+    }
+}

--- a/src/BetterStepsRecorder/UI/Settings/Export/ExportOdt.cs
+++ b/src/BetterStepsRecorder/UI/Settings/Export/ExportOdt.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Drawing;
+using System.Text;
+using System.Windows.Forms;
+
+namespace BetterStepsRecorder.UI.Settings
+{
+    public partial class ExportOdt : UserControl
+    {
+        public ExportOdt()
+        {
+            InitializeComponent();
+            LoadSettings();
+
+            // Auto-save when any checkbox changes
+            chkSummary.CheckedChanged += Checkbox_CheckedChanged;
+            chkGeneratedDate.CheckedChanged += Checkbox_CheckedChanged;
+            chkStepTimestamps.CheckedChanged += Checkbox_CheckedChanged;
+            chkAction.CheckedChanged += Checkbox_CheckedChanged;
+            chkApplication.CheckedChanged += Checkbox_CheckedChanged;
+            chkWindow.CheckedChanged += Checkbox_CheckedChanged;
+            chkElement.CheckedChanged += Checkbox_CheckedChanged;
+            chkElementType.CheckedChanged += Checkbox_CheckedChanged;
+            chkMousePosition.CheckedChanged += Checkbox_CheckedChanged;
+        }
+
+        private void LoadSettings()
+        {
+            var odtSettings = BSRSettings.Current.ExportOptions.Odt;
+
+            chkSummary.Checked = odtSettings.ShowSummary;
+            chkGeneratedDate.Checked = odtSettings.ShowGeneratedDate;
+            chkStepTimestamps.Checked = odtSettings.ShowStepTimestamps;
+            chkAction.Checked = odtSettings.ShowAction;
+            chkApplication.Checked = odtSettings.ShowApplication;
+            chkWindow.Checked = odtSettings.ShowWindow;
+            chkElement.Checked = odtSettings.ShowElement;
+            chkElementType.Checked = odtSettings.ShowElementType;
+            chkMousePosition.Checked = odtSettings.ShowMousePosition;
+        }
+
+        private void Checkbox_CheckedChanged(object sender, EventArgs e)
+        {
+            SaveSettings();
+        }
+
+        private void SaveSettings()
+        {
+            var odtSettings = BSRSettings.Current.ExportOptions.Odt;
+
+            odtSettings.ShowSummary = chkSummary.Checked;
+            odtSettings.ShowGeneratedDate = chkGeneratedDate.Checked;
+            odtSettings.ShowStepTimestamps = chkStepTimestamps.Checked;
+            odtSettings.ShowAction = chkAction.Checked;
+            odtSettings.ShowApplication = chkApplication.Checked;
+            odtSettings.ShowWindow = chkWindow.Checked;
+            odtSettings.ShowElement = chkElement.Checked;
+            odtSettings.ShowElementType = chkElementType.Checked;
+            odtSettings.ShowMousePosition = chkMousePosition.Checked;
+
+            BSRSettings.Current.Save();
+        }
+    }
+}

--- a/src/BetterStepsRecorder/UI/Settings/Export/ExportRtf.Designer.cs
+++ b/src/BetterStepsRecorder/UI/Settings/Export/ExportRtf.Designer.cs
@@ -1,0 +1,175 @@
+namespace BetterStepsRecorder.UI.Settings
+{
+    partial class ExportRtf
+    {
+        private System.ComponentModel.IContainer components = null;
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Component Designer generated code
+
+        private void InitializeComponent()
+        {
+            lblNote = new Label();
+            lblHeader = new Label();
+            chkSummary = new CheckBox();
+            chkGeneratedDate = new CheckBox();
+            lblPerStep = new Label();
+            chkStepTimestamps = new CheckBox();
+            lblDetailStrip = new Label();
+            chkAction = new CheckBox();
+            chkApplication = new CheckBox();
+            chkWindow = new CheckBox();
+            chkElement = new CheckBox();
+            chkElementType = new CheckBox();
+            chkMousePosition = new CheckBox();
+            SuspendLayout();
+            
+            lblNote.ForeColor = System.Drawing.SystemColors.GrayText;
+            lblNote.Location = new System.Drawing.Point(3, 12);
+            lblNote.Name = "lblNote";
+            lblNote.Size = new System.Drawing.Size(450, 46);
+            lblNote.TabIndex = 0;
+            lblNote.Text = "Choose which metadata to include in the RTF export.\r\nThe step description and screenshot are always included.";
+            
+            lblHeader.AutoSize = true;
+            lblHeader.Font = new System.Drawing.Font("Segoe UI", 8.5F, System.Drawing.FontStyle.Bold);
+            lblHeader.Location = new System.Drawing.Point(3, 70);
+            lblHeader.Name = "lblHeader";
+            lblHeader.Size = new System.Drawing.Size(53, 19);
+            lblHeader.TabIndex = 1;
+            lblHeader.Text = "Header";
+            
+            chkSummary.AutoSize = true;
+            chkSummary.Location = new System.Drawing.Point(20, 95);
+            chkSummary.Name = "chkSummary";
+            chkSummary.Size = new System.Drawing.Size(343, 24);
+            chkSummary.TabIndex = 2;
+            chkSummary.Text = "Summary bar (Steps / Start / End / Duration)";
+            chkSummary.UseVisualStyleBackColor = true;
+            
+            chkGeneratedDate.AutoSize = true;
+            chkGeneratedDate.Location = new System.Drawing.Point(20, 119);
+            chkGeneratedDate.Name = "chkGeneratedDate";
+            chkGeneratedDate.Size = new System.Drawing.Size(137, 24);
+            chkGeneratedDate.TabIndex = 3;
+            chkGeneratedDate.Text = "Generated date";
+            chkGeneratedDate.UseVisualStyleBackColor = true;
+            
+            lblPerStep.AutoSize = true;
+            lblPerStep.Font = new System.Drawing.Font("Segoe UI", 8.5F, System.Drawing.FontStyle.Bold);
+            lblPerStep.Location = new System.Drawing.Point(3, 155);
+            lblPerStep.Name = "lblPerStep";
+            lblPerStep.Size = new System.Drawing.Size(65, 19);
+            lblPerStep.TabIndex = 4;
+            lblPerStep.Text = "Per-Step";
+            
+            chkStepTimestamps.AutoSize = true;
+            chkStepTimestamps.Location = new System.Drawing.Point(20, 180);
+            chkStepTimestamps.Name = "chkStepTimestamps";
+            chkStepTimestamps.Size = new System.Drawing.Size(147, 24);
+            chkStepTimestamps.TabIndex = 5;
+            chkStepTimestamps.Text = "Step timestamps";
+            chkStepTimestamps.UseVisualStyleBackColor = true;
+            
+            lblDetailStrip.AutoSize = true;
+            lblDetailStrip.Font = new System.Drawing.Font("Segoe UI", 8.5F, System.Drawing.FontStyle.Bold);
+            lblDetailStrip.Location = new System.Drawing.Point(3, 216);
+            lblDetailStrip.Name = "lblDetailStrip";
+            lblDetailStrip.Size = new System.Drawing.Size(83, 19);
+            lblDetailStrip.TabIndex = 6;
+            lblDetailStrip.Text = "Detail Strip";
+            
+            chkAction.AutoSize = true;
+            chkAction.Location = new System.Drawing.Point(20, 241);
+            chkAction.Name = "chkAction";
+            chkAction.Size = new System.Drawing.Size(75, 24);
+            chkAction.TabIndex = 7;
+            chkAction.Text = "Action";
+            chkAction.UseVisualStyleBackColor = true;
+            
+            chkApplication.AutoSize = true;
+            chkApplication.Location = new System.Drawing.Point(20, 265);
+            chkApplication.Name = "chkApplication";
+            chkApplication.Size = new System.Drawing.Size(110, 24);
+            chkApplication.TabIndex = 8;
+            chkApplication.Text = "Application";
+            chkApplication.UseVisualStyleBackColor = true;
+            
+            chkWindow.AutoSize = true;
+            chkWindow.Location = new System.Drawing.Point(20, 289);
+            chkWindow.Name = "chkWindow";
+            chkWindow.Size = new System.Drawing.Size(87, 24);
+            chkWindow.TabIndex = 9;
+            chkWindow.Text = "Window";
+            chkWindow.UseVisualStyleBackColor = true;
+            
+            chkElement.AutoSize = true;
+            chkElement.Location = new System.Drawing.Point(20, 313);
+            chkElement.Name = "chkElement";
+            chkElement.Size = new System.Drawing.Size(86, 24);
+            chkElement.TabIndex = 10;
+            chkElement.Text = "Element";
+            chkElement.UseVisualStyleBackColor = true;
+            
+            chkElementType.AutoSize = true;
+            chkElementType.Location = new System.Drawing.Point(20, 337);
+            chkElementType.Name = "chkElementType";
+            chkElementType.Size = new System.Drawing.Size(121, 24);
+            chkElementType.TabIndex = 11;
+            chkElementType.Text = "Element Type";
+            chkElementType.UseVisualStyleBackColor = true;
+            
+            chkMousePosition.AutoSize = true;
+            chkMousePosition.Location = new System.Drawing.Point(20, 361);
+            chkMousePosition.Name = "chkMousePosition";
+            chkMousePosition.Size = new System.Drawing.Size(133, 24);
+            chkMousePosition.TabIndex = 12;
+            chkMousePosition.Text = "Mouse Position";
+            chkMousePosition.UseVisualStyleBackColor = true;
+            
+            AutoScaleDimensions = new System.Drawing.SizeF(8F, 20F);
+            AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            Controls.Add(chkMousePosition);
+            Controls.Add(chkElementType);
+            Controls.Add(chkElement);
+            Controls.Add(chkWindow);
+            Controls.Add(chkApplication);
+            Controls.Add(chkAction);
+            Controls.Add(lblDetailStrip);
+            Controls.Add(chkStepTimestamps);
+            Controls.Add(lblPerStep);
+            Controls.Add(chkGeneratedDate);
+            Controls.Add(chkSummary);
+            Controls.Add(lblHeader);
+            Controls.Add(lblNote);
+            Name = "ExportRtf";
+            Size = new System.Drawing.Size(472, 400);
+            ResumeLayout(false);
+            PerformLayout();
+        }
+
+        #endregion
+
+        private System.Windows.Forms.Label lblNote;
+        private System.Windows.Forms.Label lblHeader;
+        private System.Windows.Forms.CheckBox chkSummary;
+        private System.Windows.Forms.CheckBox chkGeneratedDate;
+        private System.Windows.Forms.Label lblPerStep;
+        private System.Windows.Forms.CheckBox chkStepTimestamps;
+        private System.Windows.Forms.Label lblDetailStrip;
+        private System.Windows.Forms.CheckBox chkAction;
+        private System.Windows.Forms.CheckBox chkApplication;
+        private System.Windows.Forms.CheckBox chkWindow;
+        private System.Windows.Forms.CheckBox chkElement;
+        private System.Windows.Forms.CheckBox chkElementType;
+        private System.Windows.Forms.CheckBox chkMousePosition;
+    }
+}

--- a/src/BetterStepsRecorder/UI/Settings/Export/ExportRtf.cs
+++ b/src/BetterStepsRecorder/UI/Settings/Export/ExportRtf.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Drawing;
+using System.Text;
+using System.Windows.Forms;
+
+namespace BetterStepsRecorder.UI.Settings
+{
+    public partial class ExportRtf : UserControl
+    {
+        public ExportRtf()
+        {
+            InitializeComponent();
+            LoadSettings();
+
+            // Auto-save when any checkbox changes
+            chkSummary.CheckedChanged += Checkbox_CheckedChanged;
+            chkGeneratedDate.CheckedChanged += Checkbox_CheckedChanged;
+            chkStepTimestamps.CheckedChanged += Checkbox_CheckedChanged;
+            chkAction.CheckedChanged += Checkbox_CheckedChanged;
+            chkApplication.CheckedChanged += Checkbox_CheckedChanged;
+            chkWindow.CheckedChanged += Checkbox_CheckedChanged;
+            chkElement.CheckedChanged += Checkbox_CheckedChanged;
+            chkElementType.CheckedChanged += Checkbox_CheckedChanged;
+            chkMousePosition.CheckedChanged += Checkbox_CheckedChanged;
+        }
+
+        private void LoadSettings()
+        {
+            var rtfSettings = BSRSettings.Current.ExportOptions.Rtf;
+
+            chkSummary.Checked = rtfSettings.ShowSummary;
+            chkGeneratedDate.Checked = rtfSettings.ShowGeneratedDate;
+            chkStepTimestamps.Checked = rtfSettings.ShowStepTimestamps;
+            chkAction.Checked = rtfSettings.ShowAction;
+            chkApplication.Checked = rtfSettings.ShowApplication;
+            chkWindow.Checked = rtfSettings.ShowWindow;
+            chkElement.Checked = rtfSettings.ShowElement;
+            chkElementType.Checked = rtfSettings.ShowElementType;
+            chkMousePosition.Checked = rtfSettings.ShowMousePosition;
+        }
+
+        private void Checkbox_CheckedChanged(object sender, EventArgs e)
+        {
+            SaveSettings();
+        }
+
+        private void SaveSettings()
+        {
+            var rtfSettings = BSRSettings.Current.ExportOptions.Rtf;
+
+            rtfSettings.ShowSummary = chkSummary.Checked;
+            rtfSettings.ShowGeneratedDate = chkGeneratedDate.Checked;
+            rtfSettings.ShowStepTimestamps = chkStepTimestamps.Checked;
+            rtfSettings.ShowAction = chkAction.Checked;
+            rtfSettings.ShowApplication = chkApplication.Checked;
+            rtfSettings.ShowWindow = chkWindow.Checked;
+            rtfSettings.ShowElement = chkElement.Checked;
+            rtfSettings.ShowElementType = chkElementType.Checked;
+            rtfSettings.ShowMousePosition = chkMousePosition.Checked;
+
+            BSRSettings.Current.Save();
+        }
+    }
+}

--- a/src/BetterStepsRecorder/UI/Settings/Settings.Designer.cs
+++ b/src/BetterStepsRecorder/UI/Settings/Settings.Designer.cs
@@ -45,7 +45,10 @@
             TreeNode treeNode10 = new TreeNode("Screenshot", new TreeNode[] { treeNode6, treeNode9 });
             TreeNode treeNode11 = new TreeNode("HTML");
             TreeNode treeNode12 = new TreeNode("Markdown");
-            TreeNode treeNode13 = new TreeNode("Export", new TreeNode[] { treeNode11, treeNode12 });
+            TreeNode treeNode13 = new TreeNode("RTF");
+            TreeNode treeNode14 = new TreeNode("ODT");
+            TreeNode treeNode15 = new TreeNode("Obsidian");
+            TreeNode treeNode16 = new TreeNode("Export", new TreeNode[] { treeNode11, treeNode12, treeNode13, treeNode14, treeNode15 });
             treeView_Settings = new TreeView();
             textBox_SearchSettings = new TextBox();
             panel_settings = new Panel();
@@ -83,9 +86,15 @@
             treeNode11.Text = "HTML";
             treeNode12.Name = "Settings_ExportMarkdown";
             treeNode12.Text = "Markdown";
-            treeNode13.Name = "Settings_Export";
-            treeNode13.Text = "Export";
-            treeView_Settings.Nodes.AddRange(new TreeNode[] { treeNode1, treeNode4, treeNode10, treeNode13 });
+            treeNode13.Name = "Settings_ExportRtf";
+            treeNode13.Text = "RTF";
+            treeNode14.Name = "Settings_ExportOdt";
+            treeNode14.Text = "ODT";
+            treeNode15.Name = "Settings_ExportObsidian";
+            treeNode15.Text = "Obsidian";
+            treeNode16.Name = "Settings_Export";
+            treeNode16.Text = "Export";
+            treeView_Settings.Nodes.AddRange(new TreeNode[] { treeNode1, treeNode4, treeNode10, treeNode16 });
             treeView_Settings.Size = new Size(244, 367);
             treeView_Settings.TabIndex = 0;
             // 

--- a/src/BetterStepsRecorder/UI/Settings/Settings.cs
+++ b/src/BetterStepsRecorder/UI/Settings/Settings.cs
@@ -87,6 +87,15 @@ namespace BetterStepsRecorder.UI.Settings
                 case "Settings_ExportMarkdown":
                     newView = new ExportMarkdown();
                     break;
+                case "Settings_ExportRtf":
+                    newView = new ExportRtf();
+                    break;
+                case "Settings_ExportOdt":
+                    newView = new ExportOdt();
+                    break;
+                case "Settings_ExportObsidian":
+                    newView = new ExportObsidian();
+                    break;
             }
 
             if (newView != null)
@@ -301,6 +310,12 @@ namespace BetterStepsRecorder.UI.Settings
                     return new ExportHtml();
                 case "Settings_ExportMarkdown":
                     return new ExportMarkdown();
+                case "Settings_ExportRtf":
+                    return new ExportRtf();
+                case "Settings_ExportOdt":
+                    return new ExportOdt();
+                case "Settings_ExportObsidian":
+                    return new ExportObsidian();
                 default:
                     return null;
             }
@@ -489,6 +504,15 @@ namespace BetterStepsRecorder.UI.Settings
                         break;
                     case "Settings_ExportMarkdown":
                         tempControl = new ExportMarkdown();
+                        break;
+                    case "Settings_ExportRtf":
+                        tempControl = new ExportRtf();
+                        break;
+                    case "Settings_ExportOdt":
+                        tempControl = new ExportOdt();
+                        break;
+                    case "Settings_ExportObsidian":
+                        tempControl = new ExportObsidian();
                         break;
                 }
 


### PR DESCRIPTION
updated exports to more closely align with HTML / Markdown (added settings)

Closes #22 

<img width="876" height="492" alt="image" src="https://github.com/user-attachments/assets/b32f7275-d5c6-4865-973f-8b883e535405" />

## RTF
<img width="1034" height="766" alt="image" src="https://github.com/user-attachments/assets/15b0baad-5615-4671-9a61-ef4e10cd2f02" />

## ODT
<img width="2122" height="989" alt="image" src="https://github.com/user-attachments/assets/dd68dc17-26d3-4432-92e7-24e1a9944841" />


## Obsidian
<img width="1623" height="1326" alt="image" src="https://github.com/user-attachments/assets/eb109898-9072-45a7-a103-ad08ca97ee72" />
